### PR TITLE
Switch to Mmaped memory for `default_buffer`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,12 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 
 [compat]

--- a/README.org
+++ b/README.org
@@ -6,13 +6,12 @@
 Bumper.jl is an experimental package that aims to make working with bump allocators easy and safer (when used right).
 You can dynamically allocate memory to these bump allocators, and reset them at the end of a code block, just like
 Julia's default stack. Allocating to the a =AllocBuffer= with Bumper.jl can be just as efficient as stack allocation.
-
 The point of this is to not have to pay the hefty cost of intermediate allocations.
 
-Bumper.jl has a global default buffer, which starts off with =1MB= of capacity. You can change the default buffer size
-with =set_default_buffer_size!(nbytes)= where =nbytes= is the new size of the default buffer. If a buffer runs out of
-memory, it'll throw an error. Resizing a buffer which is in active use is not allowed, and should be
-considered memory un-safe. 
+Bumper.jl has a task-local default buffer, which can dynamically grow to be as large as your computer's physical memory pool.
+You can change the default buffer size with =set_default_buffer_size!(nbytes)= where =nbytes= is the new size of the
+default buffer. If a buffer runs out of memory, it'll throw an error. Resizing a buffer which is in active use is not allowed,
+and should be considered memory un-safe.
 
 The simplest way to use Bumper is to rely on its default buffer implicitly like so:
 #+begin_src julia
@@ -30,15 +29,13 @@ end
 f([1,2,3])
 #+end_src
 
-#+RESULTS:
 : 9
 
 
 When you use =@no_escape=, you are promising that any code enclosed in the supplied code block will not leak any memory
 created by =alloc=. That is, you are *only* allowed to do intermediate =alloc= allocations inside a =@no_escape= block,
-and the lifetime of those allocations is the block. This is important. Once a =@no_escape= block finishes running, it
+and the lifetime of those allocations is the block. **This is important.** Once a =@no_escape= block finishes running, it
 will reset its internal pointer to its position from before the block started.
-
 
 Let's compare the performance of =f= to the equivalent with an intermediate heap allocation:
 
@@ -48,13 +45,13 @@ using BenchmarkTools
 #+end_src
 
 : BenchmarkTools.Trial: 10000 samples with 997 evaluations.
-:  Range (min … max):  22.197 ns … 45.256 ns  ┊ GC (min … max): 0.00% … 0.00%
-:  Time  (median):     22.909 ns              ┊ GC (median):    0.00%
-:  Time  (mean ± σ):   23.060 ns ±  1.126 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+:  Range (min … max):  20.973 ns … 41.454 ns  ┊ GC (min … max): 0.00% … 0.00%
+:  Time  (median):     22.006 ns              ┊ GC (median):    0.00%
+:  Time  (mean ± σ):   22.212 ns ±  1.422 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 : 
-:         ▆█▇▂                                                   
-:   ▂▂▂▃▅█████▇▅▄▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▁▂▂▂▂▂ ▃
-:   22.2 ns         Histogram: frequency by time        27.4 ns <
+:       ▅█▇▃                                                     
+:   ▂▂▃▅████▆▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▁▁▂▂▁▂▁▁▂▂ ▃
+:   21 ns           Histogram: frequency by time          31 ns <
 : 
 :  Memory estimate: 0 bytes, allocs estimate: 0.
 
@@ -102,27 +99,27 @@ end
 #+end_src
 
 : BenchmarkTools.Trial: 10000 samples with 999 evaluations.
-:  Range (min … max):  10.119 ns … 23.664 ns  ┊ GC (min … max): 0.00% … 0.00%
-:  Time  (median):     10.340 ns              ┊ GC (median):    0.00%
-:  Time  (mean ± σ):   10.374 ns ±  0.456 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+:  Range (min … max):  10.120 ns … 27.037 ns  ┊ GC (min … max): 0.00% … 0.00%
+:  Time  (median):     10.521 ns              ┊ GC (median):    0.00%
+:  Time  (mean ± σ):   10.583 ns ±  0.574 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 : 
-:   ▁ ▁ ▂▃▄▇▄█▅▆▁                                               ▂
-:   █▄████████████▆▆▁▁▃▃▁▄▃▁▁▄▅▃▁▁▁▃▁▄▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▃▃▄▃▃▁▃ █
-:   10.1 ns      Histogram: log(frequency) by time      11.5 ns <
+:         ▄█                                                     
+:   ▂▂▃▅▅▅██▅▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▂
+:   10.1 ns         Histogram: frequency by time        13.6 ns <
 : 
 :  Memory estimate: 0 bytes, allocs estimate: 0.
 
 Running =default_buffer()= will give you the current task's default buffer, or you can explicitly construct an =N= byte buffer by calling =AllocBuffer(N)=.
 
 E.g. if we want to do something that requires a very large buffer temporarily, we could do this:
+
 #+begin_src julia
 let x = rand(1:100, 10_000_000), buf = AllocBuffer(2*sizeof(x))
     f(x, buf)
 end
 #+end_src
 
-: 515035101
-
+: 515000435
 
 Some miscellaneous notes:
 + =@no_escape= blocks can be nested as much as you want (so long as the allocator has enough memory to store the objects you're using.
@@ -130,8 +127,8 @@ Some miscellaneous notes:
   still use the same default buffer, and be reset once the block ends.
 + As mentioned previously, *Do not allow any memory which was initialized inside a* =@no_escape= *block to escape the block.* Doing so can cause memory
   corruption.
-+ You can use =alloc= outside of an =@no_escape= block, but that will leak memory from the buffer and cause it to overflow if you do it to many times.
-  If you accidentally do this, and need to reset the buffer, use =Bumper.reset_buffer!(::AllocBuffer)=.
++ You can use =alloc= outside of an =@no_escape= block, but that will leak memory from the buffer and cause it to overflow if you do it too many times.
+  If you accidentally do this, and need to reset the buffer, use =Bumper.reset_buffer!=.
 + =alloc(T, n...)= creates a =StrideArraysCore.PtrArray{T, length(n)}=.
 + In order to be lightweight, Bumper.jl only depends on StrideArraysCore.jl, not the full [[https://github.com/JuliaSIMD/StrideArrays.jl][StrideArrays.jl]], so if you need some of
   the more advanced functionality from StrideArrays.jl itself, you'll need to do =using StrideArrays= separately.
@@ -139,8 +136,8 @@ Some miscellaneous notes:
 
 ** Concurrency and parallelism
 
-Every task has its own *independent* default buffer which inherit the size of their parent's task buffer. A task's buffer is only created
-if it is used, so this does not slow down the spawning of Julia tasks in general. Here's a demo that the default buffers are different:
+Every task has its own *independent* default buffer. A task's buffer is only created if it is used, so this does not slow down the
+spawning of Julia tasks in general. Here's a demo that the default buffers are different:
 
 #+begin_src julia
 using Bumper
@@ -152,12 +149,11 @@ end
 
 : false
 
-
 Whereas if we don't spawn any tasks, we don't have to worry about unnecessary buffer creation:
 
 #+begin_src julia
-let b = default_buffer() # The default buffer on the main task
-    b2 = default_buffer() # Get the default buffer on an asychronous task
+let b = default_buffer()
+    b2 = default_buffer() 
     b2 === b
 end
 #+end_src
@@ -180,7 +176,6 @@ end
 #+end_src
 
 : false
-
 
 This is dynamically scoped, so any nested function calls inside the =with_buffer= block will see a modified =default_buffer=.
 

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -1,38 +1,64 @@
 module Bumper
 
-export default_buffer, alloc_nothrow, @no_escape, alloc, with_buffer, AllocBuffer, set_default_buffer_size!
+export AllocBuffer, alloc, alloc_nothrow, default_buffer, @no_escape, with_buffer
 
-using StrideArraysCore
 
+## Public
+# ------------------------------------------------------
 mutable struct AllocBuffer{Storage}
     buf::Storage
     offset::UInt
 end
 
-AllocBuffer(max_size::Int)  = AllocBuffer(Vector{UInt8}(undef, max_size), UInt(0))
-AllocBuffer(storage) = AllocBuffer(storage, UInt(0))
+function default_buffer end
+function alloc end
+macro no_escape end
+function no_escape end
+function with_buffer end
+function set_default_buffer_size! end
+allow_ptr_array_to_escape() = false
+function alloc_nothrow end
+
+## Private
+# ------------------------------------------------------
+module Internals
+
+using StrideArraysCore, Mmap, MacroTools
+import Bumper: AllocBuffer,  alloc, default_buffer, allow_ptr_array_to_escape, set_default_buffer_size!, with_buffer, no_escape, @no_escape,
+    alloc_nothrow
+
+const default_buffer_key = gensym(:buffer)
+const buffer_size = Ref(Sys.total_physical_memory() - 1_000)
 
 Base.pointer(b::AllocBuffer) = pointer(b.buf)
 
-const buffer_size = Ref(1_000_000)
-const default_buffer_key = gensym(:buffer)
+AllocBuffer(max_size::Int)  = AllocBuffer(Vector{UInt8}(undef, max_size), UInt(0))
+AllocBuffer(storage) = AllocBuffer(storage, UInt(0))
+
 function default_buffer()
-    get!(() -> AllocBuffer(buffer_size[]), task_local_storage(), default_buffer_key)::AllocBuffer{Vector{UInt8}}
+    get!(() -> AllocBuffer(mmap(Vector{UInt8}, buffer_size[])), task_local_storage(), default_buffer_key)::AllocBuffer{Vector{UInt8}}
 end
 
 function set_default_buffer_size!(sz::Int)
-    resize!(default_buffer().buf, sz)
     buffer_size[] = sz
+    b = default_buffer()
+    b.buf = mmap(Vector{UInt8}, buffer_size[])
+    GC.gc()
     sz
 end
 
-reset_buffer!(b::AllocBuffer) = b.offset = UInt(0)
-reset_buffer!() = reset_buffer!(default_buffer())
+function reset_buffer!(b::AllocBuffer = default_buffer())
+    if b === default_buffer()
+        b.buf = mmap(Vector{UInt8}, buffer_size[])
+    end
+    GC.gc()
+    b.offset = UInt(0)
+end
 
 function alloc_ptr(b::AllocBuffer, sz::Int)
     ptr = pointer(b) + b.offset
     b.offset += sz
-    b.offset > sizeof(b.buf) && error("alloc: Buffer out of memory. Consider resizing it, or checking for memory leaks.")
+    b.offset > sizeof(b.buf) && oom_error(b)
     ptr
 end
 
@@ -43,53 +69,61 @@ function alloc_ptr_nothrow(b::AllocBuffer, sz::Int)
 end
 
 
+@noinline function oom_error()
+    error("alloc: Buffer out of memory. This might be a sign of a memory leak.
+Use Bumper.reset_buffer!() or Bumper.reset_buffer!(b::AllocBuffer) to reclaim its memory.")
+end
+
 function no_escape(f, b::AllocBuffer)
     offset = b.offset
     res = f()
     b.offset = offset
     if res isa PtrArray && !(allow_ptr_array_to_escape())
-        error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
+        esc_err()
     end
     res
 end
 no_escape(f) = no_escape(f, default_buffer())
 
-macro no_escape(b, ex)
-    quote
-        b = $(esc(b))
-        offset = b.offset
-        res = $(esc(ex))
-        b.offset = offset
-        if res isa PtrArray && !(allow_ptr_array_to_escape())
-            error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
-        end
-        res
-    end
+macro no_escape(b_ex, ex)
+    _no_escape_macro(b_ex, ex, __module__)
 end
+
 macro no_escape(ex)
+    _no_escape_macro(:(default_buffer()), ex, __module__)
+end
+
+function _no_escape_macro(b_ex, ex, __module__)
+    @gensym b offset
+    cleaned_ex = MacroTools.postwalk(ex) do x
+        Base.isexpr(x, :return) ? Expr(:block, :($b.offset = $offset), x) : x
+    end
     quote
-        b = default_buffer()
-        offset = b.offset
-        res = $(esc(ex))
-        b.offset = offset
+        $b = $(esc(b_ex))
+        $offset = $b.offset
+        res = $(esc(cleaned_ex))
+        $b.offset = $offset
         if res isa PtrArray && !(allow_ptr_array_to_escape())
-            error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
+           esc_err()
         end
         res
     end
 end
 
+@noinline esc_err() =
+    error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
+
 with_buffer(f, b::AllocBuffer) = task_local_storage(f, default_buffer_key, b)
+
+struct NoThrow end
 
 function StrideArraysCore.PtrArray{T}(b::AllocBuffer, s::Vararg{Integer, N}) where {T, N}
     ptr = reinterpret(Ptr{T}, alloc_ptr(b, prod(s) * sizeof(T)))
     PtrArray(ptr, s)
 end
 
-alloc(::Type{T}, s...) where {T} = PtrArray{T}(default_buffer(), s...)
-alloc(::Type{T}, buf::AllocBuffer, s...) where {T} = PtrArray{T}(buf, s...)
-
-struct NoThrow end
+alloc(::Type{T}, s::Integer...) where {T} = PtrArray{T}(default_buffer(), s...)
+alloc(::Type{T}, buf::AllocBuffer, s::Integer...) where {T} = PtrArray{T}(buf, s...)
 
 function StrideArraysCore.PtrArray{T}(b::AllocBuffer, ::NoThrow, s::Vararg{Integer, N}) where {T, N}
     ptr = reinterpret(Ptr{T}, alloc_ptr_nothrow(b, prod(s) * sizeof(T)))
@@ -98,4 +132,7 @@ end
 
 alloc_nothrow(::Type{T}, buf::AllocBuffer, s...) where {T} = PtrArray{T}(buf, NoThrow(), s...) 
 
-end
+
+end # Internals
+
+end # Bumper

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test, Bumper
 
-set_default_buffer_size!(1000)
+# set_default_buffer_size!(1000)
 
 function f(x::Vector{Int})
     @no_escape begin
@@ -22,11 +22,12 @@ end
     v = [1,2,3]
     b = AllocBuffer(100)
 
+    @test f(v) == 9
+    @test f(v, b) == 9
+    
     @test @allocated(f(v)) == 0
     @test @allocated(f(v, b)) == 0
 
-    @test f(v) == 9
-    @test f(v, b) == 9
 end
 
 @testset "tasks and buffer switching" begin


### PR DESCRIPTION
Following @chriselrod's suggestion in https://github.com/MasonProtter/Bumper.jl/issues/9#issuecomment-1605809860. Using this, we can make the default buffer huge without having to actually allocate that memory unless we reach it. 