### PR TITLE
Fix `oom_error` function inconsistency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -79,7 +79,7 @@ function alloc_ptr_nothrow(b::AllocBuffer, sz::Int)
 end
 
 
-@noinline function oom_error()
+@noinline function oom_error(b)
     error("alloc: Buffer out of memory. This might be a sign of a memory leak.
 Use Bumper.reset_buffer!() or Bumper.reset_buffer!(b::AllocBuffer) to reclaim its memory.")
 end


### PR DESCRIPTION
First of all, thanks for this really useful package!

I detected an issue in the latest (v0.3.0) version of Bumper.jl. The `oom_error` function is called with a single argument `b::AllocBuffer` in:

https://github.com/MasonProtter/Bumper.jl/blob/55d0ded058f7c3dd0bfac9c2802401bc2a4bc4bd/src/Bumper.jl#L68-L73

However, the only definition of `oom_error` takes no arguments:

https://github.com/MasonProtter/Bumper.jl/blob/55d0ded058f7c3dd0bfac9c2802401bc2a4bc4bd/src/Bumper.jl#L82-L85

Even in cases where the OOM error is never reached, this causes [JET.jl](https://github.com/aviatesk/JET.jl) to complain when analysing code which uses Bumper.jl.

This PR fixes the issue by including an unused positional argument to `oom_error`.