### PR TITLE
[Breaking] Replace `alloc` with `@alloc`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,13 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
-MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 
 [compat]
 StrideArraysCore = "0.3, 0.4, 0.5"
-MacroTools = "0.5"
 julia = "1.6"
 
 [extras]

--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 :END:
 * Bumper.jl
 
-Bumper.jl is an experimental package that aims to make working with bump allocators (also known as arena allocators)
+Bumper.jl is a package that aims to make working with bump allocators (also known as arena allocators)
 easy and safer (though not totally safe!). You can dynamically allocate memory to these bump allocators, and reset
 them at the end of a code block, just like Julia's stack. Allocating to the a =AllocBuffer= with Bumper.jl
 can be just as efficient as stack allocation. The point of this is to not have to pay the hefty cost of

--- a/README.org
+++ b/README.org
@@ -9,6 +9,10 @@ them at the end of a code block, just like Julia's default stack. Allocating to 
 can be just as efficient as stack allocation. The point of this is to not have to pay the hefty cost of
 intermediate allocations.
 
+** Basics
+#+HTML: <details><summary>Click me!</summary>
+#+HTML: <p>
+
 Bumper.jl has a task-local default buffer, which can dynamically grow to be one eigth the size of your computer's
 physical memory pool. You can change the default buffer size with =set_default_buffer_size!(nbytes)= where =nbytes=
 is the new size of the default buffer. If a buffer runs out of memory, it'll throw an error. Resizing a buffer which
@@ -20,8 +24,11 @@ using Bumper
 using StrideArrays # Not necessary, but makes operations like broadcasting with Bumper.jl faster.
 
 function f(x::Vector{Int})
+    # Set up a scope where memory may be allocated, and does not escape:
     @no_escape begin
-        y = alloc(Int, length(x)) # This will allocate a `PtrArray` from StrideArraysCore.jl using memory from the default buffer.
+        # Allocate a `PtrArray` from StrideArraysCore.jl using memory from the default buffer.
+        y = @alloc(Int, length(x))
+        # Now do some stuff with that vector:
         y .= x .+ 1
         sum(y)
     end
@@ -32,9 +39,8 @@ f([1,2,3])
 
 : 9
 
-
 When you use =@no_escape=, you are promising that any code enclosed in the supplied code block will not leak any memory
-created by =alloc=. That is, you are *only* allowed to do intermediate =alloc= allocations inside a =@no_escape= block,
+created by =@alloc=. That is, you are *only* allowed to do intermediate =@alloc= allocations inside a =@no_escape= block,
 and the lifetime of those allocations is the block. **This is important.** Once a =@no_escape= block finishes running, it
 will reset its internal pointer to its position from before the block started.
 
@@ -45,14 +51,14 @@ using BenchmarkTools
 @benchmark f(x) setup=(x = rand(1:10, 30))
 #+end_src
 
-: BenchmarkTools.Trial: 10000 samples with 997 evaluations.
-:  Range (min … max):  20.973 ns … 41.454 ns  ┊ GC (min … max): 0.00% … 0.00%
-:  Time  (median):     22.006 ns              ┊ GC (median):    0.00%
-:  Time  (mean ± σ):   22.212 ns ±  1.422 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+: BenchmarkTools.Trial: 10000 samples with 998 evaluations.
+:  Range (min … max):  14.676 ns … 30.970 ns  ┊ GC (min … max): 0.00% … 0.00%
+:  Time  (median):     15.219 ns              ┊ GC (median):    0.00%
+:  Time  (mean ± σ):   15.367 ns ±  1.246 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 : 
-:       ▅█▇▃                                                     
-:   ▂▂▃▅████▆▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▁▁▂▂▁▂▁▁▂▂ ▃
-:   21 ns           Histogram: frequency by time          31 ns <
+:     █▆▁▁▆▇▂                                                    
+:   ▂▆███████▅▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▂▂▂▂▁▁▁▂▂ ▃
+:   14.7 ns         Histogram: frequency by time          20 ns <
 : 
 :  Memory estimate: 0 bytes, allocs estimate: 0.
 
@@ -60,58 +66,65 @@ and
 
 #+begin_src julia
 function g(x::Vector{Int})
-    y = StrideArray{Int}(undef, length(x))
-    y .= x .+ 1
+    y = x .+ 1
     sum(y)
 end
 
 @benchmark g(x) setup=(x = rand(1:10, 30))
 #+end_src
 
-: BenchmarkTools.Trial: 10000 samples with 995 evaluations.
-:  Range (min … max):  30.975 ns …   4.676 μs  ┊ GC (min … max):  0.00% … 98.25%
-:  Time  (median):     74.342 ns               ┊ GC (median):     0.00%
-:  Time  (mean ± σ):   72.151 ns ± 228.449 ns  ┊ GC (mean ± σ):  17.50% ±  5.47%
+#+RESULTS:
+: BenchmarkTools.Trial: 10000 samples with 994 evaluations.
+:  Range (min … max):  33.705 ns … 898.148 ns  ┊ GC (min … max): 0.00% … 89.85%
+:  Time  (median):     37.325 ns               ┊ GC (median):    0.00%
+:  Time  (mean ± σ):   41.774 ns ±  46.284 ns  ┊ GC (mean ± σ):  8.75% ±  7.42%
 : 
-:    █▂                                                           
-:   ▂██▄▄▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁▂▂▁▁▁▁▂▂▄▅▅▄▄▄▅▆▅▄▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▁▂▂ ▃
-:   31 ns           Histogram: frequency by time          111 ns <
+:      ▁▃▇█▇▆▅▃▂▁▁▁▁                                             ▂
+:   ▇▆███████████████▇▇▆▇▆▆▆▆▅▄▅▄▅▄▅▄▅▅▃▄▃▃▄▄▇████▆▅▄▄▅▄▁▄▃▄▄▁▄▄ █
+:   33.7 ns       Histogram: log(frequency) by time        65 ns <
 : 
 :  Memory estimate: 304 bytes, allocs estimate: 1.
 
 Nice speedup!
 
-However, we can actually do better if we're okay with manually manipulating some state. The way I invoked =@no_escape= and =alloc= implicitly used
-the default buffer, and fetching that default buffer is not as fast as using a =const= global variable, because Bumper.jl is working to protect
+However, we can actually go a little faster better if we're okay with manually passing around a buffer.
+The way I invoked =@no_escape= and =alloc= implicitly used the default buffer, and fetching that
+default buffer is not as fast as using a =const= global variable, because Bumper.jl is working to protect
 you against concurrency bugs (more on that in the next section).
 
-If we provide the buffer to =f= explicitly, these safety features aren't needed:
+If we provide the buffer to =f= explicitly, 
 #+begin_src julia
 function f(x, buf::AllocBuffer)
     @no_escape buf begin # <----- Notice I specified buf here
-        y = alloc(Int, buf, length(x)) # <----- and here
+        y = @alloc(Int, length(x)) 
         y .= x .+ 1
         sum(y)
     end
 end
 
-@benchmark f(x, buf) setup=(x = rand(1:10, 30);
-                            buf = default_buffer())
+@benchmark f(x, buf) setup = begin
+    x   = rand(1:10, 30)
+    buf = default_buffer()
+end
 #+end_src
 
 : BenchmarkTools.Trial: 10000 samples with 999 evaluations.
-:  Range (min … max):  10.120 ns … 27.037 ns  ┊ GC (min … max): 0.00% … 0.00%
-:  Time  (median):     10.521 ns              ┊ GC (median):    0.00%
-:  Time  (mean ± σ):   10.583 ns ±  0.574 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+:  Range (min … max):  10.129 ns … 24.942 ns  ┊ GC (min … max): 0.00% … 0.00%
+:  Time  (median):     10.259 ns              ┊ GC (median):    0.00%
+:  Time  (mean ± σ):   10.296 ns ±  0.429 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 : 
-:         ▄█                                                     
-:   ▂▂▃▅▅▅██▅▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▂
-:   10.1 ns         Histogram: frequency by time        13.6 ns <
+:   ▁█           ▆                                               
+:   ██▃▄▅▃▃▃▄▄▃▃▆█▃▃▄▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▂▁▁▁▂▁▁▂▁▁▁▂▂▂▁▁▁▁▁▂▁▂▂▁▂ ▃
+:   10.1 ns         Histogram: frequency by time        11.2 ns <
 : 
 :  Memory estimate: 0 bytes, allocs estimate: 0.
 
-Running =default_buffer()= will give you the current task's default buffer. You can explicitly construct an =N= byte buffer by calling =AllocBuffer(N)=,
-or you can create a buffer which can dynamically grow to be as big as your system memory with =AllocBuffer()=.
+If you manually specify a buffer like this, it is your responsibility to ensure that you don't have
+multiple concurrent tasks using that buffer at the same time.
+
+Running =default_buffer()= will give you the current task's default buffer. You can explicitly construct
+your own =N= byte buffer by calling =AllocBuffer(N)=, or you can create a buffer which can dynamically
+grow to be as big as your 1/8th of your system memory with =AllocBuffer()=.
 
 E.g. if we want to do something that requires a very large buffer temporarily, we could do this:
 
@@ -123,23 +136,42 @@ end
 
 : 515000435
 
-Some miscellaneous notes:
+#+HTML: </details>
+#+HTML: </p>
+
+** Important notes
+
+#+HTML: <details><summary>Click me!</summary>
+#+HTML: <p>
+
 + =@no_escape= blocks can be nested as much as you want (so long as the allocator has enough memory to store the objects you're using.
-+ =alloc(T, n...)= is dynamically scoped, meaning that you can have deeply nested =alloc= calls inside a =@no_escape= block, and they'll still use the same default buffer, and be reset once the block ends.
-+ Bumper.jl only supports =isbits= types. You cannot use it for allocating vectors containing mutable, abstract, or other pointer-backed objects. 
-+ As mentioned previously, *Do not allow any array which was initialized inside a* =@no_escape= *block to escape the block.* Doing so will cause incorrect results.
-+ You can use =alloc= outside of an =@no_escape= block, but that will leak memory from the buffer and cause it to overflow if you do it too many times.
-  If you accidentally do this, and need to reset the buffer, use =Bumper.reset_buffer!=.
-+ =alloc(T, n...)= creates a =StrideArraysCore.PtrArray{T, length(n)}=.
++ The =@alloc= macro can only be used directly inside of a =@no_escape= block, and it will always use the buffer that the
+  corresponding =@no_escape= block uses.
++ If for some reason you need to be able to use =@alloc= outside of the scope of the =@no_escape= block, there is a
+  function  =Bumper.alloc(T, buf, n...)= which takes in an explicit buffer =buf= and uses it to allocate an array of
+  element type =T=, and dimensions =n...=. Using this is not as safe as =@alloc= and not recommended.
++ Bumper.jl only supports =isbits= types. You cannot use it for allocating vectors containing mutable, abstract, or
+  other pointer-backed objects. 
++ As mentioned previously, *Do not allow any array which was initialized inside a* =@no_escape=
+  *block to escape the block.* Doing so will cause incorrect results.
++ If you accidentally overblow a buffer, via e.g. a memory leak, you need to reset the buffer. Use
+  =Bumper.reset_buffer!= to do this.
 + In order to be lightweight, Bumper.jl only depends on [[https://github.com/JuliaSIMD/StrideArraysCore.jl][StrideArraysCore.jl]], not the full [[https://github.com/JuliaSIMD/StrideArrays.jl][StrideArrays.jl]], so if you need some of the more advanced functionality from StrideArrays.jl itself, you'll need to do =using StrideArrays= separately.
 + You are not allowed to use =return= or =@goto= inside a =@no_escape= block, since this could compromise the cleanup it performs after the block finishes.
 + If you use Bumper.jl, please consider submitting a sample of your use-case so I can include it in the test suite.
 + Bumper.jl is experimental, and may have bugs. Let me know if you find any.
 
+#+HTML: </details>
+#+HTML: </p>
+
 ** Concurrency and parallelism
 
-Every task has its own *independent* default buffer. A task's buffer is only created if it is used, so this does not slow down the
-spawning of Julia tasks in general. Here's a demo that the default buffers are different:
+#+HTML: <details><summary>Click me!</summary>
+#+HTML: <p>
+
+Every task has its own *independent* default buffer. A task's buffer is only created if it is
+used, so this does not slow down the spawning of Julia tasks in general. Here's a demo
+showing that the default buffers are different:
 
 #+begin_src julia
 using Bumper
@@ -162,34 +194,196 @@ end
 
 : true
 
-Because of this, we don't have to worry about =@no_escape begin ... alloc() ... end= blocks on different threads or tasks interfering
-with each other, so long as they are only operating on buffers local to that task or the =default_buffer()=.
+Because of this, we don't have to worry about =@no_escape begin ... @alloc() ... end= blocks on
+different threads or tasks interfering with each other, so long as they are only operating on
+buffers local to that task or the =default_buffer()=.
+
+#+HTML: </details>
+#+HTML: </p>
 
 ** Changing buffers
+
+#+HTML: <details><summary>Click me!</summary>
+#+HTML: <p>
 
 If for some reason you want to run a chunk of code with the default bufferr temporarily modified, you can use =with_buffer(f, b)= for that:
 
 #+begin_src julia
-let b = default_buffer()
-    with_buffer(AllocBuffer(100)) do
-        b === default_buffer()
+let b1 = default_buffer()
+    b2 = AllocBuffer(10000)
+    with_buffer(b2) do
+        @show default_buffer() == b2
     end
-end
+    @show default_buffer() == b1
+end;
 #+end_src
 
-: false
+: default_buffer() == b2 = true
+: default_buffer() == b1 = true
 
 This is dynamically scoped, so any nested function calls inside the =with_buffer= block will see a modified =default_buffer=.
 
-** Advanced usage with StaticCompiler.jl
+#+HTML: </details>
+#+HTML: </p>
 
-Bumper.jl can be useful to those who are trying to compile standalone static binaries with StaticCompiler.jl since those binaries
-do not have Julia's GC available to them. To do so, we won't be able to count on the global default buffer or =with_buffer=, but
-will instead have to explicitly provide it. We'll also need to use =alloc_nothrow= instead due to a current limitation of
-StaticCompiler.
+** Docstrings
+#+HTML: <details><summary>Click me!</summary>
+#+HTML: <p>
+
+#+begin_src julia
+@doc @alloc
+#+end_src
+
+#+begin_export markdown
+```
+@alloc(T, n::Int...) -> PtrArray{T, length(n)}
+```
+
+This can only be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
+
+Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of it's parent `@no_escape` block has undefined contents.
+#+end_export
+
+#+begin_src julia
+@doc @no_escape
+#+end_src
+
+#+begin_export markdown
+```
+@no_escape([buf=default_buffer()], expr)
+```
+
+Record the current state of `buf` (which defaults to the `default_buffer()` if there is only one argument), and then run the code in `expr` and then reset `buf` back to the state it was in before the code ran. This allows us to allocate memory within the `expr` using `@alloc`, and then have those arrays be automatically de-allocated once the expression is over. This is a restrictive but highly efficient form of memory management.
+
+Using `return`, `@goto`, and `@label` are not allowed inside of `@no_escape` block.
+
+Example:
+
+```
+function f(x::Vector{Int})
+    # Set up a scope where memory may be allocated, and does not escape:
+    @no_escape begin
+        # Allocate a `PtrArray` from StrideArraysCore.jl using memory from the default buffer.
+        y = @alloc(Int, length(x))
+        # Now do some stuff with that vector:
+        y .= x .+ 1
+       sum(y)
+    end
+end
+```
+#+end_export
+
+#+begin_src julia
+@doc AllocBuffer
+#+end_src
+
+#+begin_export markdown
+```
+AllocBuffer(max_size::Int) -> AllocBuffer{Vector{UInt8}}
+```
+
+Create an AllocBuffer storing a vector of bytes which can store as most `max_size` bytes
+
+```
+AllocBuffer(storage::T) -> AllocBuffer{T}
+```
+
+Create an AllocBuffer using `storage` as the memory slab. Whatever `storage` is, it must support `Base.pointer`, and the `sizeof` function must give the number of bytes available to that pointer.
+
+```
+AllocBuffer() -> AllocBuffer{Vector{UInt8}}
+```
+
+Create an AllocBuffer whose size is determined by `Bumper.buffer_size[]`. 
+
+```
+AllocBuffer{StorageType}
+```
+
+This is a single bump allocator that could be used to store some memory of type `StorageType`. Do not manually manipulate the fields of an AllocBuffer that is in use.
+#+end_export
+
+#+begin_src julia
+@doc default_buffer()
+#+end_src
+
+#+begin_export markdown
+default_buffer() -> AllocBuffer{Vector{UInt8}}
+
+Return the current task-local default buffer, if one does not exist in the current task, it will create one.
+#+end_export
+
+#+begin_src julia
+@doc with_buffer()
+#+end_src
+
+#+begin_export markdown
+```
+with_buffer(f, buf::AllocBuffer)
+```
+
+Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal `default_buffer`.
+
+Example:
+
+```
+julia> let b1 = default_buffer()
+           b2 = AllocBuffer(10000)
+           with_buffer(b2) do
+               @show default_buffer() == b2
+           end
+           @show default_buffer() == b1
+       end
+default_buffer() == b2 = true
+default_buffer() == b1 = true
+true
+```
+#+end_export
+
+#+begin_src julia
+@doc Bumper.set_default_buffer_size!
+#+end_src
+
+#+begin_export markdown
+```
+Bumper.set_default_buffer_size!(n::Int)
+```
+
+Change the size that future `AllocBuffer()`s will be created with.
+#+end_export
+
+
+#+begin_src julia
+@doc Bumper.reset_buffer!
+#+end_src
+
+#+begin_export markdown
+```
+Bumper.reset_buffer!(buf::AllocBuffer=default_buffer())
+```
+
+This resets an AllocBuffer's offset to zero, effectively making it like a freshly allocated buffer. This might be necessary to use if you accidentally over-allocate a buffer.
+#+end_export
+
+
+
+#+HTML: </details>
+#+HTML: </p>
+
+** Advanced usage with StaticCompiler.jl
+#+HTML: <details><summary>Click me!</summary>
+#+HTML: <p>
+
+Bumper.jl can be useful to those who are trying to compile standalone static binaries with
+StaticCompiler.jl ince those binaries do not have Julia's GC available to them. To do so, we
+won't be able to count on the global default buffer or =with_buffer=, but will instead have
+to explicitly provide it. We'll also need to use =@alloc_nothrow= instead due to a current
+limitation of StaticCompiler. =@alloc_nothrow= is the same as =@alloc= but it doesn't throw
+errors.
 
 #+begin_src julia
 using Bumper, StaticCompiler, StaticTools
+
 function foo(argc::Int, argv::Ptr{Ptr{UInt8}})
     n = argparse(Int, argv, 2)
     v = MallocArray{UInt8}(undef, 100) # 100 bytes of malloc'd memory to work with.
@@ -199,7 +393,7 @@ function foo(argc::Int, argv::Ptr{Ptr{UInt8}})
     for i ∈ 1:10000
         @no_escape buf begin # <----- Note that we specify buf here.
             # allocate a chunk of n bytes at a time before resetting, so we don't spill over our 100 byte limit
-            x = alloc_nothrow(Int, buf, n) # <--- Note that we're using alloc_nothrow
+            x = @alloc_nothrow(Int, n) # <--- Note that we're using @alloc_nothrow
             x .= 1
             s += sum(x)
         end
@@ -217,3 +411,5 @@ run(`./foo 5`) # run it
 : The sum is: 50000
 : Process(`./foo 5`, ProcessExited(0))
 
+#+HTML: </details>
+#+HTML: </p>

--- a/README.org
+++ b/README.org
@@ -5,9 +5,10 @@
 
 Bumper.jl is an experimental package that aims to make working with bump allocators (also known as arena allocators)
 easy and safer (though not totally safe!). You can dynamically allocate memory to these bump allocators, and reset
-them at the end of a code block, just like Julia's default stack. Allocating to the a =AllocBuffer= with Bumper.jl
+them at the end of a code block, just like Julia's stack. Allocating to the a =AllocBuffer= with Bumper.jl
 can be just as efficient as stack allocation. The point of this is to not have to pay the hefty cost of
 intermediate allocations.
+
 
 ** Basics
 #+HTML: <details><summary>Click me!</summary>
@@ -30,7 +31,7 @@ function f(x::Vector{Int})
         y = @alloc(Int, length(x))
         # Now do some stuff with that vector:
         y .= x .+ 1
-        sum(y)
+        sum(y) # It's okay for the sum of y to escape the block, but references to y itself must not do so!
     end
 end
 
@@ -42,7 +43,7 @@ f([1,2,3])
 When you use =@no_escape=, you are promising that any code enclosed in the supplied code block will not leak any memory
 created by =@alloc=. That is, you are *only* allowed to do intermediate =@alloc= allocations inside a =@no_escape= block,
 and the lifetime of those allocations is the block. **This is important.** Once a =@no_escape= block finishes running, it
-will reset its internal pointer to its position from before the block started.
+will reset its internal pointer to the position it had before the block started.
 
 Let's compare the performance of =f= to the equivalent with an intermediate heap allocation:
 
@@ -52,13 +53,13 @@ using BenchmarkTools
 #+end_src
 
 : BenchmarkTools.Trial: 10000 samples with 998 evaluations.
-:  Range (min … max):  14.676 ns … 30.970 ns  ┊ GC (min … max): 0.00% … 0.00%
-:  Time  (median):     15.219 ns              ┊ GC (median):    0.00%
-:  Time  (mean ± σ):   15.367 ns ±  1.246 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+:  Range (min … max):  14.707 ns … 27.205 ns  ┊ GC (min … max): 0.00% … 0.00%
+:  Time  (median):     15.280 ns              ┊ GC (median):    0.00%
+:  Time  (mean ± σ):   15.353 ns ±  0.497 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 : 
-:     █▆▁▁▆▇▂                                                    
-:   ▂▆███████▅▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▂▂▂▂▁▁▁▂▂ ▃
-:   14.7 ns         Histogram: frequency by time          20 ns <
+:            ▄▄█▄▄▂                                              
+:   ▂▂▂▂▂▂▃▃▇███████▆▅▃▃▃▃▂▂▂▂▂▁▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂ ▃
+:   14.7 ns         Histogram: frequency by time        17.4 ns <
 : 
 :  Memory estimate: 0 bytes, allocs estimate: 0.
 
@@ -145,6 +146,8 @@ end
 #+HTML: <p>
 
 + =@no_escape= blocks can be nested as much as you want (so long as the allocator has enough memory to store the objects you're using.
++ At the end of a `@no_escape` block, all memory allocations from inside that block are erased and the buffer is reset to its previous
+  state.
 + The =@alloc= macro can only be used directly inside of a =@no_escape= block, and it will always use the buffer that the
   corresponding =@no_escape= block uses.
 + If for some reason you need to be able to use =@alloc= outside of the scope of the =@no_escape= block, there is a
@@ -236,6 +239,7 @@ Sorry, I haven't found a better way to make these display yet
 @doc @alloc
 #+end_src
 
+
 #+begin_src markdown
 ```
 @alloc(T, n::Int...) -> PtrArray{T, length(n)}
@@ -245,6 +249,7 @@ This can only be used inside a `@no_escape` block to allocate a `PtrArray` whose
 
 Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of it's parent `@no_escape` block has undefined contents.
 #+end_src
+
 
 __________________
 
@@ -258,6 +263,8 @@ __________________
 ```
 
 Record the current state of `buf` (which defaults to the `default_buffer()` if there is only one argument), and then run the code in `expr` and then reset `buf` back to the state it was in before the code ran. This allows us to allocate memory within the `expr` using `@alloc`, and then have those arrays be automatically de-allocated once the expression is over. This is a restrictive but highly efficient form of memory management.
+
+See also `Bumper.checkpoint_save`, and `Bumper.checkpoint_restore!`.
 
 Using `return`, `@goto`, and `@label` are not allowed inside of `@no_escape` block.
 
@@ -276,6 +283,7 @@ function f(x::Vector{Int})
 end
 ```
 #+end_src
+
 
 __________________
 
@@ -316,10 +324,13 @@ __________________
 #+end_src
 
 #+begin_src markdown
+```
 default_buffer() -> AllocBuffer{Vector{UInt8}}
+```
 
 Return the current task-local default buffer, if one does not exist in the current task, it will create one.
 #+end_src
+
 
 __________________
 
@@ -349,6 +360,8 @@ default_buffer() == b1 = true
 true
 ```
 #+end_src
+
+
 __________________
 
 #+begin_src julia
@@ -360,8 +373,9 @@ __________________
 Bumper.set_default_buffer_size!(n::Int)
 ```
 
-Change the size that future `AllocBuffer()`s will be created with.
+Change the size (in number of bytes) of the default buffer. This should not be done while any buffers are in use, as their contents may become undefined.
 #+end_src
+
 __________________
 
 #+begin_src julia
@@ -374,6 +388,38 @@ Bumper.reset_buffer!(buf::AllocBuffer=default_buffer())
 ```
 
 This resets an AllocBuffer's offset to zero, effectively making it like a freshly allocated buffer. This might be necessary to use if you accidentally over-allocate a buffer.
+#+end_src
+
+__________________
+
+#+begin_src julia
+@doc Bumper.checkpoint_save
+#+end_src
+
+#+begin_src markdown
+```
+Bumper.checkpoint_save(buf::AllocBuffer = default_buffer()) -> Checkpoint
+```
+
+Returns a `Checkpoint` object which stores the state of an `AllocBuffer` at a given point in a program. One can then use `Bumper.checkpoint_restore!(cp::Checkpoint)` to later on restore the state of the buffer to it's earlier saved state, undoing any bump allocations which happened in the meantime on that buffer.
+
+Users should prefer to use `@no_escape` instead of `checkpoint_save` and `checkpoint_restore`, which is a safer and more structured way of doing the same thing.
+#+end_src
+
+__________________
+
+#+begin_src julia
+@doc Bumper.checkpoint_restore!
+#+end_src
+
+#+begin_src markdown
+```
+Bumper.checkpoint_restore!(cp::Checkpoint)
+```
+
+Restore a buffer (the one used to create the checkpoint) to the state it was in when the checkpoint was created, undoing any bump allocations which happened in the meantime on that buffer. See also `Bumper.checkpoint_save`
+
+Users should prefer to use `@no_escape` instead of `checkpoint_save` and `checkpoint_restore`, which is a safer and more structured way of doing the same thing.
 #+end_src
 
 

--- a/README.org
+++ b/README.org
@@ -234,7 +234,7 @@ This is dynamically scoped, so any nested function calls inside the =with_buffer
 @doc @alloc
 #+end_src
 
-#+begin_export markdown
+#+begin_src markdown
 ```
 @alloc(T, n::Int...) -> PtrArray{T, length(n)}
 ```
@@ -242,13 +242,13 @@ This is dynamically scoped, so any nested function calls inside the =with_buffer
 This can only be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
 
 Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of it's parent `@no_escape` block has undefined contents.
-#+end_export
+#+end_src
 
 #+begin_src julia
 @doc @no_escape
 #+end_src
 
-#+begin_export markdown
+#+begin_src markdown
 ```
 @no_escape([buf=default_buffer()], expr)
 ```
@@ -271,7 +271,7 @@ function f(x::Vector{Int})
     end
 end
 ```
-#+end_export
+#+end_src
 
 #+begin_src julia
 @doc AllocBuffer

--- a/README.org
+++ b/README.org
@@ -230,6 +230,8 @@ This is dynamically scoped, so any nested function calls inside the =with_buffer
 #+HTML: <details><summary>Click me!</summary>
 #+HTML: <p>
 
+Sorry, I haven't found a better way to make these display yet
+
 #+begin_src julia
 @doc @alloc
 #+end_src
@@ -277,7 +279,7 @@ end
 @doc AllocBuffer
 #+end_src
 
-#+begin_export markdown
+#+begin_src markdown
 ```
 AllocBuffer(max_size::Int) -> AllocBuffer{Vector{UInt8}}
 ```
@@ -301,23 +303,23 @@ AllocBuffer{StorageType}
 ```
 
 This is a single bump allocator that could be used to store some memory of type `StorageType`. Do not manually manipulate the fields of an AllocBuffer that is in use.
-#+end_export
+#+end_src
 
 #+begin_src julia
 @doc default_buffer()
 #+end_src
 
-#+begin_export markdown
+#+begin_src markdown
 default_buffer() -> AllocBuffer{Vector{UInt8}}
 
 Return the current task-local default buffer, if one does not exist in the current task, it will create one.
-#+end_export
+#+end_src
 
 #+begin_src julia
 @doc with_buffer()
 #+end_src
 
-#+begin_export markdown
+#+begin_src markdown
 ```
 with_buffer(f, buf::AllocBuffer)
 ```
@@ -338,32 +340,32 @@ default_buffer() == b2 = true
 default_buffer() == b1 = true
 true
 ```
-#+end_export
+#+end_src
 
 #+begin_src julia
 @doc Bumper.set_default_buffer_size!
 #+end_src
 
-#+begin_export markdown
+#+begin_src markdown
 ```
 Bumper.set_default_buffer_size!(n::Int)
 ```
 
 Change the size that future `AllocBuffer()`s will be created with.
-#+end_export
+#+end_src
 
 
 #+begin_src julia
 @doc Bumper.reset_buffer!
 #+end_src
 
-#+begin_export markdown
+#+begin_src markdown
 ```
 Bumper.reset_buffer!(buf::AllocBuffer=default_buffer())
 ```
 
 This resets an AllocBuffer's offset to zero, effectively making it like a freshly allocated buffer. This might be necessary to use if you accidentally over-allocate a buffer.
-#+end_export
+#+end_src
 
 
 

--- a/README.org
+++ b/README.org
@@ -246,6 +246,8 @@ This can only be used inside a `@no_escape` block to allocate a `PtrArray` whose
 Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of it's parent `@no_escape` block has undefined contents.
 #+end_src
 
+__________________
+
 #+begin_src julia
 @doc @no_escape
 #+end_src
@@ -274,6 +276,8 @@ function f(x::Vector{Int})
 end
 ```
 #+end_src
+
+__________________
 
 #+begin_src julia
 @doc AllocBuffer
@@ -305,6 +309,8 @@ AllocBuffer{StorageType}
 This is a single bump allocator that could be used to store some memory of type `StorageType`. Do not manually manipulate the fields of an AllocBuffer that is in use.
 #+end_src
 
+__________________
+
 #+begin_src julia
 @doc default_buffer()
 #+end_src
@@ -315,16 +321,18 @@ default_buffer() -> AllocBuffer{Vector{UInt8}}
 Return the current task-local default buffer, if one does not exist in the current task, it will create one.
 #+end_src
 
+__________________
+
 #+begin_src julia
 @doc with_buffer()
 #+end_src
 
 #+begin_src markdown
 ```
-with_buffer(f, buf::AllocBuffer)
+with_buffer(f, buf::AllocBuffer{Vector{UInt8}})
 ```
 
-Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal `default_buffer`.
+Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal `default_buffer`. This currently only works with `AllocBuffer{Vector{UInt8}}`.
 
 Example:
 
@@ -341,6 +349,7 @@ default_buffer() == b1 = true
 true
 ```
 #+end_src
+__________________
 
 #+begin_src julia
 @doc Bumper.set_default_buffer_size!
@@ -353,7 +362,7 @@ Bumper.set_default_buffer_size!(n::Int)
 
 Change the size that future `AllocBuffer()`s will be created with.
 #+end_src
-
+__________________
 
 #+begin_src julia
 @doc Bumper.reset_buffer!

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -87,8 +87,6 @@ You must obey all the rules from `@alloc`.
 function alloc end
 
 
-function no_escape end
-
 """
     with_buffer(f, buf::AllocBuffer)
 
@@ -219,17 +217,6 @@ end
 Use Bumper.reset_buffer!() or Bumper.reset_buffer!(b::AllocBuffer) to reclaim its memory.")
 end
 
-function no_escape(f, b::AllocBuffer)
-    offset = b.offset
-    res = f()
-    b.offset = offset
-    if res isa PtrArray && !(allow_ptr_array_to_escape())
-        esc_err()
-    end
-    res
-end
-no_escape(f) = no_escape(f, default_buffer())
-
 macro no_escape(b_ex, ex)
     _no_escape_macro(b_ex, ex, __module__)
 end
@@ -240,7 +227,6 @@ end
 
 isexpr(ex) = ex isa Expr
 isexpr(ex, head) = isexpr(ex) && ex.head == head
-isexpr(ex, head, count) = isexpr(ex, head) && length(ex.args) == count
 
 function _no_escape_macro(b_ex, _ex, __module__)
     @gensym b offset

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -1,30 +1,139 @@
 module Bumper
 
-export AllocBuffer, alloc, alloc_nothrow, default_buffer, @no_escape, with_buffer
+export AllocBuffer, @alloc, default_buffer, @no_escape, with_buffer
 
 
 ## Public API
 # ------------------------------------------------------
+
+"""
+    AllocBuffer{StorageType}
+
+This is a single bump allocator that could be used to store some memory of type `StorageType`.
+Do not manually manipulate the fields of an AllocBuffer that is in use.
+"""
 mutable struct AllocBuffer{Storage}
     buf::Storage
     offset::UInt
 end
 
-function default_buffer end
-function alloc end
+
+"""
+    @no_escape([buf=default_buffer()], expr)
+
+Record the current state of `buf` (which defaults to the `default_buffer()` if there is only one argument), and then run
+the code in `expr` and then reset `buf` back to the state it was in before the code ran. This allows us to allocate memory
+within the `expr` using `@alloc`, and then have those arrays be automatically de-allocated once the expression is over. This
+is a restrictive but highly efficient form of memory management.
+
+Using `return`, `@goto`, and `@label` are not allowed inside of `@no_escape` block.
+
+Example:
+
+    function f(x::Vector{Int})
+        # Set up a scope where memory may be allocated, and does not escape:
+        @no_escape begin
+            # Allocate a `PtrArray` from StrideArraysCore.jl using memory from the default buffer.
+            y = @alloc(Int, length(x))
+            # Now do some stuff with that vector:
+            y .= x .+ 1
+           sum(y)
+        end
+    end
+"""
 macro no_escape end
-function no_escape end
-function with_buffer end
-function set_default_buffer_size! end
-allow_ptr_array_to_escape() = false
+
+"""
+    @alloc(T, n::Int...) -> PtrArray{T, length(n)}
+
+This can only be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions
+are determined by `n`. The memory used to allocate this array will come from the buffer
+associated with the enclosing `@no_escape` block.
+
+Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do
+not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the
+`@no_escape` block ends. Any array allocated in this way which is found outside of it's parent
+`@no_escape` block has undefined contents.
+"""
+macro alloc(args...)
+    error("The @alloc macro may only be used inside of a @no_escape block.")
+end
+
+"""
+    @alloc_nothrow(T, n::Int...) -> PtrArray{T, length(n)}
+
+Just like `@alloc` but it won't throw an error if the size you requested is too big. Don't use this
+unless you're doing something weird like using StaticCompiler.jl and can't handle errors.
+"""
+macro alloc_nothrow(args...)
+    error("The @alloc macro may only be used inside of a @no_escape block.")
+end
 function alloc_nothrow end
+
+"""
+   default_buffer() -> AllocBuffer{Vector{UInt8}}
+
+Return the current task-local default buffer, if one does not exist in the current task, it will
+create one.
+"""
+function default_buffer end
+
+"""
+    alloc(T, b::AllocBuffer, n::Int...) -> PtrArray{T, length(n)}
+
+Function-based alternative to `@alloc` which allocates onto a specified `AllocBuffer`.
+You must obey all the rules from `@alloc`.
+"""
+function alloc end
+
+
+function no_escape end
+
+"""
+    with_buffer(f, buf::AllocBuffer)
+
+Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal `default_buffer`.
+
+Example:
+
+    julia> let b1 = default_buffer()
+               b2 = AllocBuffer(10000)
+               with_buffer(b2) do
+                   @show default_buffer() == b2
+               end
+               @show default_buffer() == b1
+           end
+    default_buffer() == b2 = true
+    default_buffer() == b1 = true
+    true
+"""
+function with_buffer end
+
+"""
+    Bumper.set_default_buffer_size!(n::Int)
+
+Change the size that future `AllocBuffer()`s will be created with.
+"""
+function set_default_buffer_size! end
+
+
+allow_ptr_array_to_escape() = false
+
+"""
+    Bumper.reset_buffer!(buf::AllocBuffer=default_buffer())
+
+This resets an AllocBuffer's offset to zero, effectively making it like a freshly allocated buffer. This might be
+necessary to use if you accidentally over-allocate a buffer.
+"""
 function reset_buffer! end
+
+
 
 ## Private
 # ------------------------------------------------------
 module Internals
 
-using StrideArraysCore, MacroTools
+using StrideArraysCore
 import Bumper: AllocBuffer,  alloc, default_buffer, allow_ptr_array_to_escape, set_default_buffer_size!,
     with_buffer, no_escape, @no_escape, alloc_nothrow, reset_buffer!
 
@@ -39,12 +148,37 @@ function total_physical_memory()
 end
 
 const default_buffer_key = gensym(:buffer)
+
+"""
+    buffer_size :: RefValue{Int}
+
+The default size in bytes of buffers created by calling `AllocBuffer()`
+"""
 const buffer_size = Ref(total_physical_memory() ÷ 8)
 
 Base.pointer(b::AllocBuffer) = pointer(b.buf)
 
+"""
+    AllocBuffer(max_size::Int) -> AllocBuffer{Vector{UInt8}}
+
+Create an AllocBuffer storing a vector of bytes which can store as most `max_size` bytes
+"""
 AllocBuffer(max_size::Int)  = AllocBuffer(Vector{UInt8}(undef, max_size), UInt(0))
+
+"""
+    AllocBuffer(storage::T) -> AllocBuffer{T}
+
+Create an AllocBuffer using `storage` as the memory slab. Whatever `storage` is, it must
+support `Base.pointer`, and the `sizeof` function must give the number of bytes available
+to that pointer.
+"""
 AllocBuffer(storage) = AllocBuffer(storage, UInt(0))
+
+"""
+    AllocBuffer() -> AllocBuffer{Vector{UInt8}}
+
+Create an AllocBuffer whose size is determined by `Bumper.buffer_size[]`. 
+"""
 AllocBuffer() = AllocBuffer(Vector{UInt8}(undef, buffer_size[]), UInt(0))
 
 function default_buffer()
@@ -69,7 +203,7 @@ end
 function alloc_ptr(b::AllocBuffer, sz::Int)
     ptr = pointer(b) + b.offset
     b.offset += sz
-    b.offset > sizeof(b.buf) && oom_error(b)
+    b.offset > sizeof(b.buf) && oom_error()
     ptr
 end
 
@@ -80,7 +214,7 @@ function alloc_ptr_nothrow(b::AllocBuffer, sz::Int)
 end
 
 
-@noinline function oom_error(b)
+@noinline function oom_error()
     error("alloc: Buffer out of memory. This might be a sign of a memory leak.
 Use Bumper.reset_buffer!() or Bumper.reset_buffer!(b::AllocBuffer) to reclaim its memory.")
 end
@@ -104,19 +238,48 @@ macro no_escape(ex)
     _no_escape_macro(:(default_buffer()), ex, __module__)
 end
 
-function _no_escape_macro(b_ex, ex, __module__)
+isexpr(ex) = ex isa Expr
+isexpr(ex, head) = isexpr(ex) && ex.head == head
+isexpr(ex, head, count) = isexpr(ex, head) && length(ex.args) == count
+
+function _no_escape_macro(b_ex, _ex, __module__)
     @gensym b offset
     e_offset = esc(offset)
+    # This'll be the variable labelling the active buffer
     e_b = esc(b)
-    # We need to macroexpand the code in case the user has a macro in the body which has return or goto in it
-    MacroTools.postwalk(macroexpand(__module__, ex)) do x
-        @gensym rv
-        if MacroTools.isexpr(x, :return) 
-            error("The `return` keyword is not allowed to be used inside the `@no_escape` macro")
-        elseif MacroTools.isexpr(x, :symbolicgoto) # && (x.args[1] ∉ enclosed_labels)
-            error("`@goto` statements are not allowed to be used inside the `@no_escape` macro")
+    function recursive_handler(ex)
+        if isexpr(ex)
+            if isexpr(ex, :macrocall)
+                if ex.args[1] == Symbol("@alloc")
+                    # replace calls to @alloc(T, size...) with alloc(T, buf, size...) where buf
+                    # is the current buffer in use.
+                    Expr(:call, _alloc, b, recursive_handler.(ex.args[3:end])...)
+                elseif ex.args[1] == Symbol("@alloc_nothrow")
+                    Expr(:call, _alloc_nothrow, b, recursive_handler.(ex.args[3:end])...)
+                elseif ex.args[1] == Symbol("@no_escape")
+                    # If we encounter nested @no_escape blocks, we'll leave them alone
+                    ex
+                else
+                    # All other macros must be macroexpanded in case the user has a macro
+                    # in the body which has return or goto in it
+                    expanded = macroexpand(__module__, ex; recursive=false)
+                    recursive_handler(expanded)
+                end
+            elseif isexpr(ex, :return)
+                error("The `return` keyword is not allowed to be used inside the `@no_escape` macro")
+            elseif isexpr(ex, :symbolicgoto) 
+                error("`@goto` statements are not allowed to be used inside the `@no_escape` macro")
+            elseif isexpr(ex, :symboliclabel) 
+                error("`@label` statements are not allowed to be used inside the `@no_escape` macro")
+            else
+                Expr(ex.head, recursive_handler.(ex.args)...)
+            end
+        else
+            ex
         end
     end
+    ex = recursive_handler(_ex)
+
     quote
         $e_b = $(esc(b_ex))
         $e_offset = getfield($e_b, :offset)
@@ -141,16 +304,17 @@ function StrideArraysCore.PtrArray{T}(b::AllocBuffer, s::Vararg{Integer, N}) whe
     PtrArray(ptr, s)
 end
 
-alloc(::Type{T}, s::Integer...) where {T} = PtrArray{T}(default_buffer(), s...)
+# alloc(::Type{T}, s::Integer...) where {T} = PtrArray{T}(default_buffer(), s...)
 alloc(::Type{T}, buf::AllocBuffer, s::Integer...) where {T} = PtrArray{T}(buf, s...)
+_alloc(buf::AllocBuffer, ::Type{T}, s::Integer...) where {T} = PtrArray{T}(buf, s...)
 
 function StrideArraysCore.PtrArray{T}(b::AllocBuffer, ::NoThrow, s::Vararg{Integer, N}) where {T, N}
     ptr = convert(Ptr{T}, alloc_ptr_nothrow(b, prod(s) * sizeof(T)))
     PtrArray(ptr, s)
 end
 
-alloc_nothrow(::Type{T}, buf::AllocBuffer, s...) where {T} = PtrArray{T}(buf, NoThrow(), s...) 
-
+alloc_nothrow(::Type{T}, buf::AllocBuffer, s...) where {T}  = PtrArray{T}(buf, NoThrow(), s...) 
+_alloc_nothrow(buf::AllocBuffer, ::Type{T}, s...) where {T} = PtrArray{T}(buf, NoThrow(), s...) 
 
 end # Internals
 

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -88,9 +88,9 @@ function alloc end
 
 
 """
-    with_buffer(f, buf::AllocBuffer)
+    with_buffer(f, buf::AllocBuffer{Vector{UInt8}})
 
-Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal `default_buffer`.
+Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal `default_buffer`. This currently only works with `AllocBuffer{Vector{UInt8}}`.
 
 Example:
 
@@ -281,7 +281,7 @@ end
 @noinline esc_err() =
     error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
 
-with_buffer(f, b::AllocBuffer) = task_local_storage(f, default_buffer_key, b)
+with_buffer(f, b::AllocBuffer{Vector{UInt}}) = task_local_storage(f, default_buffer_key, b)
 
 struct NoThrow end
 

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -3,8 +3,6 @@ module Bumper
 export AllocBuffer, @alloc, default_buffer, @no_escape, with_buffer
 
 
-## Public API
-# ------------------------------------------------------
 
 """
     AllocBuffer{StorageType}
@@ -17,7 +15,6 @@ mutable struct AllocBuffer{Storage}
     offset::UInt
 end
 
-
 """
     @no_escape([buf=default_buffer()], expr)
 
@@ -25,6 +22,8 @@ Record the current state of `buf` (which defaults to the `default_buffer()` if t
 the code in `expr` and then reset `buf` back to the state it was in before the code ran. This allows us to allocate memory
 within the `expr` using `@alloc`, and then have those arrays be automatically de-allocated once the expression is over. This
 is a restrictive but highly efficient form of memory management.
+
+See also `Bumper.checkpoint_save`, and `Bumper.checkpoint_restore!`.
 
 Using `return`, `@goto`, and `@label` are not allowed inside of `@no_escape` block.
 
@@ -68,10 +67,17 @@ unless you're doing something weird like using StaticCompiler.jl and can't handl
 macro alloc_nothrow(args...)
     error("The @alloc macro may only be used inside of a @no_escape block.")
 end
+
+"""
+    Bumper.alloc_nothrow(T, buf, n::Int...) -> PtrArray{T, length(n)}
+
+Just like `Bumper.alloc` but it won't throw an error if the size you requested is too big. Don't use this
+unless you're doing something weird like using StaticCompiler.jl and can't handle errors.
+"""
 function alloc_nothrow end
 
 """
-   default_buffer() -> AllocBuffer{Vector{UInt8}}
+    default_buffer() -> AllocBuffer{Vector{UInt8}}
 
 Return the current task-local default buffer, if one does not exist in the current task, it will
 create one.
@@ -82,10 +88,11 @@ function default_buffer end
     alloc(T, b::AllocBuffer, n::Int...) -> PtrArray{T, length(n)}
 
 Function-based alternative to `@alloc` which allocates onto a specified `AllocBuffer`.
-You must obey all the rules from `@alloc`.
+You must obey all the rules from `@alloc`, but you can use this outside of the lexical
+scope of `@no_escape` for specific (but dangerous!) circumstances where you cannot avoid
+a scope barrier between the two.
 """
 function alloc end
-
 
 """
     with_buffer(f, buf::AllocBuffer{Vector{UInt8}})
@@ -110,7 +117,8 @@ function with_buffer end
 """
     Bumper.set_default_buffer_size!(n::Int)
 
-Change the size that future `AllocBuffer()`s will be created with.
+Change the size (in number of bytes) of the default buffer. This should not be done
+while any buffers are in use, as their contents may become undefined.
 """
 function set_default_buffer_size! end
 
@@ -126,182 +134,38 @@ necessary to use if you accidentally over-allocate a buffer.
 function reset_buffer! end
 
 
+struct Checkpoint{Store}
+    buf::AllocBuffer{Store}
+    offset::UInt
+end
+
+"""
+    Bumper.checkpoint_save(buf::AllocBuffer = default_buffer()) -> Checkpoint
+
+Returns a `Checkpoint` object which stores the state of an `AllocBuffer` at a given point in
+a program. One can then use `Bumper.checkpoint_restore!(cp::Checkpoint)` to later on restore
+the state of the buffer to it's earlier saved state, undoing any bump allocations which
+happened in the meantime on that buffer.
+
+Users should prefer to use `@no_escape` instead of `checkpoint_save` and `checkpoint_restore`,
+which is a safer and more structured way of doing the same thing.
+"""
+function checkpoint_save end
+
+"""
+    Bumper.checkpoint_restore!(cp::Checkpoint)
+
+Restore a buffer (the one used to create the checkpoint) to the state it was in when the
+checkpoint was created, undoing any bump allocations which happened in the meantime on that
+buffer. See also `Bumper.checkpoint_save`
+
+Users should prefer to use `@no_escape` instead of `checkpoint_save` and `checkpoint_restore`,
+which is a safer and more structured way of doing the same thing.
+"""
+function checkpoint_restore! end
 
 ## Private
 # ------------------------------------------------------
-module Internals
-
-using StrideArraysCore
-import Bumper: AllocBuffer,  alloc, default_buffer, allow_ptr_array_to_escape, set_default_buffer_size!,
-    with_buffer, @no_escape, alloc_nothrow, reset_buffer!
-
-function total_physical_memory()
-    @static if isdefined(Sys, :total_physical_memory)
-        Sys.total_physical_memory()
-    elseif isdefined(Sys, :physical_memory)
-        Sys.physical_memory()
-    else
-        Sys.total_memory()
-    end
-end
-
-const default_buffer_key = gensym(:buffer)
-
-"""
-    buffer_size :: RefValue{Int}
-
-The default size in bytes of buffers created by calling `AllocBuffer()`
-"""
-const buffer_size = Ref(total_physical_memory() ÷ 8)
-
-Base.pointer(b::AllocBuffer) = pointer(b.buf)
-
-"""
-    AllocBuffer(max_size::Int) -> AllocBuffer{Vector{UInt8}}
-
-Create an AllocBuffer storing a vector of bytes which can store as most `max_size` bytes
-"""
-AllocBuffer(max_size::Int)  = AllocBuffer(Vector{UInt8}(undef, max_size), UInt(0))
-
-"""
-    AllocBuffer(storage::T) -> AllocBuffer{T}
-
-Create an AllocBuffer using `storage` as the memory slab. Whatever `storage` is, it must
-support `Base.pointer`, and the `sizeof` function must give the number of bytes available
-to that pointer.
-"""
-AllocBuffer(storage) = AllocBuffer(storage, UInt(0))
-
-"""
-    AllocBuffer() -> AllocBuffer{Vector{UInt8}}
-
-Create an AllocBuffer whose size is determined by `Bumper.buffer_size[]`. 
-"""
-AllocBuffer() = AllocBuffer(Vector{UInt8}(undef, buffer_size[]), UInt(0))
-
-function default_buffer()
-    get!(() -> AllocBuffer(), task_local_storage(), default_buffer_key)::AllocBuffer{Vector{UInt8}}
-end
-
-function set_default_buffer_size!(sz::Int)
-    buffer_size[] = sz
-    resize!(default_buffer(), sz)
-    GC.gc()
-    sz
-end
-
-function reset_buffer!(b::AllocBuffer = default_buffer())
-    if b === default_buffer()
-        b.buf = Vector{UInt8}(undef, buffer_size[])
-        GC.gc()
-    end
-    b.offset = UInt(0)
-end
-
-function alloc_ptr(b::AllocBuffer, sz::Int)
-    ptr = pointer(b) + b.offset
-    b.offset += sz
-    b.offset > sizeof(b.buf) && oom_error()
-    ptr
-end
-
-function alloc_ptr_nothrow(b::AllocBuffer, sz::Int)
-    ptr = pointer(b) + b.offset
-    b.offset += sz
-    ptr
-end
-
-
-@noinline function oom_error()
-    error("alloc: Buffer out of memory. This might be a sign of a memory leak.
-Use Bumper.reset_buffer!() or Bumper.reset_buffer!(b::AllocBuffer) to reclaim its memory.")
-end
-
-macro no_escape(b_ex, ex)
-    _no_escape_macro(b_ex, ex, __module__)
-end
-
-macro no_escape(ex)
-    _no_escape_macro(:(default_buffer()), ex, __module__)
-end
-
-isexpr(ex) = ex isa Expr
-isexpr(ex, head) = isexpr(ex) && ex.head == head
-
-function _no_escape_macro(b_ex, _ex, __module__)
-    @gensym b offset
-    e_offset = esc(offset)
-    # This'll be the variable labelling the active buffer
-    e_b = esc(b)
-    function recursive_handler(ex)
-        if isexpr(ex)
-            if isexpr(ex, :macrocall)
-                if ex.args[1] == Symbol("@alloc")
-                    # replace calls to @alloc(T, size...) with alloc(T, buf, size...) where buf
-                    # is the current buffer in use.
-                    Expr(:call, _alloc, b, recursive_handler.(ex.args[3:end])...)
-                elseif ex.args[1] == Symbol("@alloc_nothrow")
-                    Expr(:call, _alloc_nothrow, b, recursive_handler.(ex.args[3:end])...)
-                elseif ex.args[1] == Symbol("@no_escape")
-                    # If we encounter nested @no_escape blocks, we'll leave them alone
-                    ex
-                else
-                    # All other macros must be macroexpanded in case the user has a macro
-                    # in the body which has return or goto in it
-                    expanded = macroexpand(__module__, ex; recursive=false)
-                    recursive_handler(expanded)
-                end
-            elseif isexpr(ex, :return)
-                error("The `return` keyword is not allowed to be used inside the `@no_escape` macro")
-            elseif isexpr(ex, :symbolicgoto) 
-                error("`@goto` statements are not allowed to be used inside the `@no_escape` macro")
-            elseif isexpr(ex, :symboliclabel) 
-                error("`@label` statements are not allowed to be used inside the `@no_escape` macro")
-            else
-                Expr(ex.head, recursive_handler.(ex.args)...)
-            end
-        else
-            ex
-        end
-    end
-    ex = recursive_handler(_ex)
-
-    quote
-        $e_b = $(esc(b_ex))
-        $e_offset = getfield($e_b, :offset)
-        res = $(esc(ex))
-        $e_b.offset = $e_offset
-        if res isa PtrArray && !(allow_ptr_array_to_escape())
-           esc_err()
-        end
-        res
-    end
-end
-
-@noinline esc_err() =
-    error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
-
-with_buffer(f, b::AllocBuffer{Vector{UInt8}}) = task_local_storage(f, default_buffer_key, b)
-
-struct NoThrow end
-
-function StrideArraysCore.PtrArray{T}(b::AllocBuffer, s::Vararg{Integer, N}) where {T, N}
-    ptr = convert(Ptr{T}, alloc_ptr(b, prod(s) * sizeof(T)))
-    PtrArray(ptr, s)
-end
-
-# alloc(::Type{T}, s::Integer...) where {T} = PtrArray{T}(default_buffer(), s...)
-alloc(::Type{T}, buf::AllocBuffer, s::Integer...) where {T} = PtrArray{T}(buf, s...)
-_alloc(buf::AllocBuffer, ::Type{T}, s::Integer...) where {T} = PtrArray{T}(buf, s...)
-
-function StrideArraysCore.PtrArray{T}(b::AllocBuffer, ::NoThrow, s::Vararg{Integer, N}) where {T, N}
-    ptr = convert(Ptr{T}, alloc_ptr_nothrow(b, prod(s) * sizeof(T)))
-    PtrArray(ptr, s)
-end
-
-alloc_nothrow(::Type{T}, buf::AllocBuffer, s...) where {T}  = PtrArray{T}(buf, NoThrow(), s...) 
-_alloc_nothrow(buf::AllocBuffer, ::Type{T}, s...) where {T} = PtrArray{T}(buf, NoThrow(), s...) 
-
-end # Internals
+include("internals.jl")
 
 end # Bumper

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -133,7 +133,7 @@ module Internals
 
 using StrideArraysCore
 import Bumper: AllocBuffer,  alloc, default_buffer, allow_ptr_array_to_escape, set_default_buffer_size!,
-    with_buffer, no_escape, @no_escape, alloc_nothrow, reset_buffer!
+    with_buffer, @no_escape, alloc_nothrow, reset_buffer!
 
 function total_physical_memory()
     @static if isdefined(Sys, :total_physical_memory)
@@ -281,7 +281,7 @@ end
 @noinline esc_err() =
     error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
 
-with_buffer(f, b::AllocBuffer{Vector{UInt}}) = task_local_storage(f, default_buffer_key, b)
+with_buffer(f, b::AllocBuffer{Vector{UInt8}}) = task_local_storage(f, default_buffer_key, b)
 
 struct NoThrow end
 

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -1,0 +1,182 @@
+module Internals
+
+using StrideArraysCore
+import Bumper: AllocBuffer,  alloc, default_buffer, allow_ptr_array_to_escape, set_default_buffer_size!,
+    with_buffer, @no_escape, alloc_nothrow, reset_buffer!, Checkpoint, checkpoint_save, checkpoint_restore!
+
+function total_physical_memory()
+    @static if isdefined(Sys, :total_physical_memory)
+        Sys.total_physical_memory()
+    elseif isdefined(Sys, :physical_memory)
+        Sys.physical_memory()
+    else
+        Sys.total_memory()
+    end
+end
+
+const default_buffer_key = gensym(:buffer)
+
+"""
+    buffer_size :: RefValue{Int}
+
+The default size in bytes of buffers created by calling `AllocBuffer()`
+"""
+const buffer_size = Ref(total_physical_memory() ÷ 8)
+
+Base.pointer(b::AllocBuffer) = pointer(b.buf)
+
+"""
+    AllocBuffer(max_size::Int) -> AllocBuffer{Vector{UInt8}}
+
+Create an AllocBuffer storing a vector of bytes which can store as most `max_size` bytes
+"""
+AllocBuffer(max_size::Int)  = AllocBuffer(Vector{UInt8}(undef, max_size), UInt(0))
+
+"""
+    AllocBuffer(storage::T) -> AllocBuffer{T}
+
+Create an AllocBuffer using `storage` as the memory slab. Whatever `storage` is, it must
+support `Base.pointer`, and the `sizeof` function must give the number of bytes available
+to that pointer.
+"""
+AllocBuffer(storage) = AllocBuffer(storage, UInt(0))
+
+"""
+    AllocBuffer() -> AllocBuffer{Vector{UInt8}}
+
+Create an AllocBuffer whose size is determined by `Bumper.buffer_size[]`. 
+"""
+AllocBuffer() = AllocBuffer(Vector{UInt8}(undef, buffer_size[]), UInt(0))
+
+function default_buffer()
+    get!(() -> AllocBuffer(), task_local_storage(), default_buffer_key)::AllocBuffer{Vector{UInt8}}
+end
+
+function set_default_buffer_size!(sz::Int)
+    buffer_size[] = sz
+    resize!(default_buffer(), sz)
+    GC.gc()
+    sz
+end
+
+function reset_buffer!(b::AllocBuffer = default_buffer())
+    if b === default_buffer()
+        b.buf = Vector{UInt8}(undef, buffer_size[])
+        GC.gc()
+    end
+    b.offset = UInt(0)
+end
+
+function alloc_ptr(b::AllocBuffer, sz::Int)
+    ptr = pointer(b) + b.offset
+    b.offset += sz
+    b.offset > sizeof(b.buf) && oom_error()
+    ptr
+end
+
+function alloc_ptr_nothrow(b::AllocBuffer, sz::Int)
+    ptr = pointer(b) + b.offset
+    b.offset += sz
+    ptr
+end
+
+
+@noinline function oom_error()
+    error("alloc: Buffer out of memory. This might be a sign of a memory leak.
+Use Bumper.reset_buffer!() or Bumper.reset_buffer!(b::AllocBuffer) to reclaim its memory.")
+end
+
+macro no_escape(b_ex, ex)
+    _no_escape_macro(b_ex, ex, __module__)
+end
+
+macro no_escape(ex)
+    _no_escape_macro(:(default_buffer()), ex, __module__)
+end
+
+isexpr(ex) = ex isa Expr
+isexpr(ex, head) = isexpr(ex) && ex.head == head
+
+function _no_escape_macro(b_ex, _ex, __module__)
+    @gensym b offset
+    e_offset = esc(offset)
+    # This'll be the variable labelling the active buffer
+    e_b = esc(b)
+    function recursive_handler(ex)
+        if isexpr(ex)
+            if isexpr(ex, :macrocall)
+                if ex.args[1] == Symbol("@alloc")
+                    # replace calls to @alloc(T, size...) with alloc(T, buf, size...) where buf
+                    # is the current buffer in use.
+                    Expr(:call, _alloc, b, recursive_handler.(ex.args[3:end])...)
+                elseif ex.args[1] == Symbol("@alloc_nothrow")
+                    Expr(:call, _alloc_nothrow, b, recursive_handler.(ex.args[3:end])...)
+                elseif ex.args[1] == Symbol("@no_escape")
+                    # If we encounter nested @no_escape blocks, we'll leave them alone
+                    ex
+                else
+                    # All other macros must be macroexpanded in case the user has a macro
+                    # in the body which has return or goto in it
+                    expanded = macroexpand(__module__, ex; recursive=false)
+                    recursive_handler(expanded)
+                end
+            elseif isexpr(ex, :return)
+                error("The `return` keyword is not allowed to be used inside the `@no_escape` macro")
+            elseif isexpr(ex, :symbolicgoto) 
+                error("`@goto` statements are not allowed to be used inside the `@no_escape` macro")
+            elseif isexpr(ex, :symboliclabel) 
+                error("`@label` statements are not allowed to be used inside the `@no_escape` macro")
+            else
+                Expr(ex.head, recursive_handler.(ex.args)...)
+            end
+        else
+            ex
+        end
+    end
+    ex = recursive_handler(_ex)
+
+    quote
+        $e_b = $(esc(b_ex))
+        local cp = checkpoint_save($e_b)
+        local res = $(esc(ex))
+        checkpoint_restore!(cp)
+        if res isa PtrArray && !(allow_ptr_array_to_escape())
+           esc_err()
+        end
+        res
+    end
+end
+
+@noinline esc_err() =
+    error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
+
+with_buffer(f, b::AllocBuffer{Vector{UInt8}}) = task_local_storage(f, default_buffer_key, b)
+
+struct NoThrow end
+
+function StrideArraysCore.PtrArray{T}(b::AllocBuffer, s::Vararg{Integer, N}) where {T, N}
+    ptr = convert(Ptr{T}, alloc_ptr(b, prod(s) * sizeof(T)))
+    PtrArray(ptr, s)
+end
+
+# alloc(::Type{T}, s::Integer...) where {T} = PtrArray{T}(default_buffer(), s...)
+alloc(::Type{T}, buf::AllocBuffer, s::Integer...) where {T} = PtrArray{T}(buf, s...)
+_alloc(buf::AllocBuffer, ::Type{T}, s::Integer...) where {T} = PtrArray{T}(buf, s...)
+
+function StrideArraysCore.PtrArray{T}(b::AllocBuffer, ::NoThrow, s::Vararg{Integer, N}) where {T, N}
+    ptr = convert(Ptr{T}, alloc_ptr_nothrow(b, prod(s) * sizeof(T)))
+    PtrArray(ptr, s)
+end
+
+alloc_nothrow(::Type{T}, buf::AllocBuffer, s...) where {T}  = PtrArray{T}(buf, NoThrow(), s...) 
+_alloc_nothrow(buf::AllocBuffer, ::Type{T}, s...) where {T} = PtrArray{T}(buf, NoThrow(), s...) 
+
+
+checkpoint_save(buf::AllocBuffer = default_buffer()) = Checkpoint(buf, buf.offset)
+
+function checkpoint_restore!(cp::Checkpoint)
+    cp.buf.offset = cp.offset
+    nothing
+end
+
+end # Internals

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,9 +62,9 @@ end
         @test default_buffer() == b1
     end
     let b2 = AllocBuffer(Vector{Int}(undef, 100))
-        with_buffer(b) do
-            @test_throws Exception default_buffer()
-        end
+        @test_throws MethodError with_buffer(b2) do
+            default_buffer()
+        end 
     end
 
     @test_throws Exception Bumper.alloc(Int, b, 100000)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,11 +55,16 @@ end
     end
 
     let b1 = default_buffer()
-        b2 = AllocBuffer(Vector{Int}(undef, 100))
+        b2 = AllocBuffer(Vector{UInt8}(undef, 100))
         with_buffer(b2) do
             @test default_buffer() == b2
         end
         @test default_buffer() == b1
+    end
+    let b2 = AllocBuffer(Vector{Int}(undef, 100))
+        with_buffer(b) do
+            @test_throws Exception default_buffer()
+        end
     end
 
     @test_throws Exception Bumper.alloc(Int, b, 100000)
@@ -71,9 +76,8 @@ end
 
     @no_escape b begin
         v = @alloc_nothrow(Int, 100000)
-        @test 8*length(v) > length(b.storage)
+        @test 8*length(v) > length(b.buf)
     end
-    
 end
 
 macro sneaky_return(ex)


### PR DESCRIPTION
This is safer, and also in some situations faster. Before you'd write
```julia
function f(x::Vector{Int})
    @no_escape begin # This called default_buffer()
        y = alloc(Int, length(x)) # This also called default_buffer()
        y .= x .+ 1
        sum(y)
    end
end
```
and now you write 
```julia
function f(x::Vector{Int})
    @no_escape begin  # Only this calls default_buffer()
        y = @alloc(Int, length(x)) # this uses whatever buffer `@no_escape` uses.
        y .= x .+ 1
        sum(y)
    end
end
```
`@alloc` no longer takes an optional `buffer` argument, it is **always** associated with the `@no_escape` block that encloses it, and it cannot be used outside of a `@no_escape` block. 

This makes `@alloc` a bit more like `alloca` in some senses. I think it was a mis-feature to allow `alloc` to be used lexically outside of a `@no_escape` block.

I also spruced up the README a little and added docstrings to the API functions. Preview of the new README here: https://github.com/MasonProtter/Bumper.jl/blob/alloc-macro/README.org