### PR TITLE
Add package extension for StaticCompiler.jl

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.5.1
+
++ Added a package extension (only works on julia versions 1.9+) which lets the `AllocBuffer` work under
+StaticCompiler.jl, and defines methods like `AllocBuffer(::Type{MallocVector}, n::Int)` and `free(AllocBuffer{<:MallocArray})` for convenience. 
+
 ## Version 0.5.0
 
 + The default allocator is now something known as a *slab* allocator `SlabBuffer`. This comes with a very *slight* performance hit relative to `AllocBuffer`, but the advantage is that it scales very well from handling small allocations all the way up to handling very large allocations. It will only run out of memory when your computer runs out of memory, but it also won't hog memory that's not in use.  It is also be much faster to construct than the old default `AllocBuffer`. 

--- a/Docstrings.md
+++ b/Docstrings.md
@@ -38,18 +38,18 @@ Do not allow any references to these arrays to escape the enclosing `@no_escape`
 
 ---------------------------------------
 ```
+default_buffer(::Type{SlabBuffer}) -> SlabBuffer{16_384}
+```
+
+Return the current task-local default `SlabBuffer`, if one does not exist in the current task, it will create one automatically. This currently only works with `SlabBuffer{16_384}`, and you cannot adjust the slab size it creates.
+
+```
 default_buffer() -> SlabBuffer{16_384}
 ```
 
 Return the current task-local default `SlabBuffer`, if one does not exist in the current task, it will create one automatically. This currently only works with `SlabBuffer{16_384}`, and you cannot adjust the slab size it creates.
 
 ---------------------------------------
-```
-SlabBuffer()
-```
-
-Create a slab allocator whose slabs are of size 16384
-
 ```
 mutable struct SlabBuffer{SlabSize}
 ```
@@ -76,10 +76,10 @@ then the inner loop will run slower than normal because at each iteration, a new
 Do not manipulate the fields of a SlabBuffer that is in use.
 
 ```
-SlabBuffer{SlabSize}()
+SlabBuffer()
 ```
 
-Create a slab allocator whose slabs are of size `SlabSize`
+Create a slab allocator whose slabs are of size 16384
 
 ---------------------------------------
 ```

--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,18 @@ authors = ["MasonProtter <mason.protter@icloud.com>"]
 version = "0.5.0"
 
 [deps]
+StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"
+StaticTools = "86c06d3c-3f03-46de-9781-57580aa96d0a"
 StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 
+[weakdeps]
+StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"
+
+[extensions]
+StaticCompilerExt = "StaticCompiler"
+
 [compat]
+StaticCompiler = "0.5"
 StrideArraysCore = "0.3, 0.4, 0.5"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"
 
 [targets]
 test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,6 @@ authors = ["MasonProtter <mason.protter@icloud.com>"]
 version = "0.5.1"
 
 [deps]
-StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"
-StaticTools = "86c06d3c-3f03-46de-9781-57580aa96d0a"
 StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
 
 [weakdeps]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - [Concurrency and parallelism](#concurrency-and-parallelism)
 - [Allocators provided by Bumper](#allocators-provided-by-bumper)
 - [Creating your own allocator types](#creating-your-own-allocator-types)
+- [Usage with StaticCompiler.jl](#usage-with-staticcompiler-jl)
 - [Docstrings](Docstrings.md)
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - [Concurrency and parallelism](#concurrency-and-parallelism)
 - [Allocators provided by Bumper](#allocators-provided-by-bumper)
 - [Creating your own allocator types](#creating-your-own-allocator-types)
-- [Usage with StaticCompiler.jl](#usage-with-staticcompiler-jl)
+- [Usage with StaticCompiler.jl](#usage-with-staticcompilerjl)
 - [Docstrings](Docstrings.md)
 
 

--- a/ext/StaticCompilerExt.jl
+++ b/ext/StaticCompilerExt.jl
@@ -1,0 +1,23 @@
+module StaticCompilerExt
+
+using Bumper
+using StaticCompiler: StaticCompiler, @device_override, @print_and_throw, @c_str
+using StaticCompiler.StaticTools
+
+@device_override @noinline Bumper.AllocBufferImpl.oom_error() =
+    @print_and_throw c"alloc: Buffer out of memory. This might be a sign of a memory leak."
+
+@device_override @noinline Bumper.Internals.esc_err() =
+    @print_and_throw c"Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true"
+
+StaticTools.free(v::AllocBuffer{<:MallocArray}) = StaticTools.free(v.buf)
+function Bumper.AllocBufferImpl.AllocBuffer(::Type{<:MallocArray}, n::Int = Bumper.AllocBufferImpl.default_buffer_size)
+    AllocBuffer(MallocArray{UInt8}(undef, n))
+end
+
+# Just to make the compiler's life a little easier, let's not make it fetch and elide the current task
+# since tasks don't actually exist on-device.
+@device_override Bumper.Internals.get_task() = 0
+
+
+end # StaticCompilerExt

--- a/src/AllocBuffer.jl
+++ b/src/AllocBuffer.jl
@@ -54,7 +54,7 @@ end
 function alloc_ptr!(b::AllocBuffer, sz::Int)::Ptr{Cvoid}
     ptr = pointer(b.buf) + b.offset
     b.offset += sz
-    # b.offset > sizeof(b.buf) && oom_error()
+    b.offset > sizeof(b.buf) && oom_error()
     ptr
 end
 

--- a/src/AllocBuffer.jl
+++ b/src/AllocBuffer.jl
@@ -1,7 +1,6 @@
 module AllocBufferImpl
 
 import Bumper:
-    AllocBuffer,
     alloc_ptr!,
     checkpoint_save,
     checkpoint_restore!,
@@ -10,11 +9,25 @@ import Bumper:
     with_buffer
 
 const default_buffer_size = 128_000
-const default_buffer_key = gensym(:buffer)
+
+"""
+    AllocBuffer{StorageType}
+
+This is a simple bump allocator that could be used to store a fixed amount of memory of type
+`StorageType`, so long as `::StoreageType` supports `pointer`, and `sizeof`.
+
+Do not manually manipulate the fields of an AllocBuffer that is in use.
+"""
+mutable struct AllocBuffer{Store}
+    buf::Store
+    offset::UInt
+end
 
 AllocBuffer(max_size::Int) = AllocBuffer(Vector{UInt8}(undef, max_size), UInt(0))
 AllocBuffer(storage) = AllocBuffer(storage, UInt(0))
 AllocBuffer() = AllocBuffer(Vector{UInt8}(undef, UInt(default_buffer_size)))
+
+const default_buffer_key = gensym(:buffer)
 
 function default_buffer(::Type{AllocBuffer})
     get!(() -> AllocBuffer(), task_local_storage(), default_buffer_key)::AllocBuffer{Vector{UInt8}}
@@ -41,7 +54,7 @@ end
 function alloc_ptr!(b::AllocBuffer, sz::Int)::Ptr{Cvoid}
     ptr = pointer(b.buf) + b.offset
     b.offset += sz
-    b.offset > sizeof(b.buf) && oom_error()
+    # b.offset > sizeof(b.buf) && oom_error()
     ptr
 end
 


### PR DESCRIPTION
I'm not adding any tests for this because I don't want the instability of StaticCompiler.jl messing with the test suite, but it's useful to provide this anyways.

With this, on julia versions 1.9+ (I didn't bother with Requires.jl), you can do
```julia
using Bumper, StaticTools
function times_table(argc::Int, argv::Ptr{Ptr{UInt8}})
    argc == 3 || return printf(c"Incorrect number of command-line arguments\n")
    rows = argparse(Int64, argv, 2)            # First command-line argument
    cols = argparse(Int64, argv, 3)            # Second command-line argument

    buf = AllocBuffer(MallocVector)
	@no_escape buf begin
        M = @alloc(Int, rows, cols)
        for i=1:rows
            for j=1:cols
                M[i,j] = i*j
            end
        end
        printf(M)
    end
    free(buf)
end

using StaticCompiler
filepath = compile_executable(times_table, (Int64, Ptr{Ptr{UInt8}}), "./")
```
and then
```
shell> ./times_table 12, 7
1   2   3   4   5   6   7
2   4   6   8   10  12  14
3   6   9   12  15  18  21
4   8   12  16  20  24  28
5   10  15  20  25  30  35
6   12  18  24  30  36  42
7   14  21  28  35  42  49
8   16  24  32  40  48  56
9   18  27  36  45  54  63
10  20  30  40  50  60  70
11  22  33  44  55  66  77
12  24  36  48  60  72  84
```

cc @brenhinkeller 