### PR TITLE
add `@alloc_ptr`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,8 @@ jobs:
         version:
           - '1.6'
           - '1.7'
-          - '1.8'
           - '1.9'
+          - '1.10.0-rc1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Docstrings.md
+++ b/Docstrings.md
@@ -32,9 +32,18 @@ end
 @alloc(T, n::Int...) -> PtrArray{T, length(n)}
 ```
 
-This can only be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
+This can be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
 
-Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of it's parent `@no_escape` block has undefined contents.
+Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
+
+---------------------------------------
+```
+@alloc_ptr(n::Integer) -> Ptr{Nothing}
+```
+
+This can be used inside a `@no_escape` block to allocate a pointer whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
+
+Do not allow any references to these pointers to escape the enclosing `@no_escape` block, and do not pass these pointers to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any pointer allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
 
 ---------------------------------------
 ```
@@ -76,10 +85,16 @@ then the inner loop will run slower than normal because at each iteration, a new
 Do not manipulate the fields of a SlabBuffer that is in use.
 
 ```
-SlabBuffer()
+SlabBuffer{SlabSize}(;finalize::Bool = true)
 ```
 
-Create a slab allocator whose slabs are of size 16384
+Create a slab allocator whose slabs are of size `SlabSize`. If you set the `finalize` keyword argument to `false`, then you will need to explicitly call `Bumper.free()` when you are done with a `SlabBuffer`. This is not recommended.
+
+```
+SlabBuffer(;finalize::Bool = true)
+```
+
+Create a slab allocator whose slabs are of size 16384. If you set the `finalize` keyword argument to `false`, then you will need to explicitly call `Bumper.free()` when you are done with a `SlabBuffer`. This is not recommended.
 
 ---------------------------------------
 ```

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you use Bumper.jl, please consider submitting a sample of your use-case so I 
 ## Basics 
 
 Bumper.jl has a task-local default allocator, using a *slab allocation strategy* which can dynamically
-grow to arbitary sizes. 
+grow to arbitary sizes.
 
 The simplest way to use Bumper is to rely on its default buffer implicitly like so:
 
@@ -31,7 +31,7 @@ using StrideArrays # Not necessary, but can make operations like broadcasting wi
 function f(x)
     # Set up a scope where memory may be allocated, and does not escape:
     @no_escape begin
-        # Allocate a `PtrArray` from StrideArraysCore.jl using memory from the default buffer.
+        # Allocate a `PtrArray` (see StrideArraysCore.jl) using memory from the default buffer.
         y = @alloc(eltype(x), length(x))
         # Now do some stuff with that vector:
         y .= x .+ 1
@@ -50,6 +50,9 @@ created by `@alloc`. That is, you are *only* allowed to do intermediate `@alloc`
 and the lifetime of those allocations is the block. **This is important.** Once a `@no_escape` block finishes running, it
 will reset its internal state to the position it had before the block started, potentially overwriting or freeing any 
 arrays which were created in the block.
+
+In addition to `@alloc` for creating arrays, you can use `@alloc_ptr(n)` to get an `n`-byte pointer (of type
+`Ptr{Cvoid}`) directly.
 
 Let's compare the performance of `f` to the equivalent with an intermediate heap allocation:
 
@@ -373,7 +376,7 @@ function times_table(argc::Int, argv::Ptr{Ptr{UInt8}})
     cols = argparse(Int64, argv, 3)            # Second command-line argument
 
     buf = AllocBuffer(MallocVector)
-	@no_escape buf begin
+    @no_escape buf begin
         M = @alloc(Int, rows, cols)
         for i=1:rows
             for j=1:cols

--- a/docstring_generator.jl
+++ b/docstring_generator.jl
@@ -3,7 +3,8 @@ using Bumper
 open("Docstrings.md", "w+") do io
     println(io, "# Docstrings\n")
     println(io, "## User API\n")
-    for s ∈ (Symbol("@no_escape"), Symbol("@alloc"), :default_buffer, :SlabBuffer, :reset_buffer!, :with_buffer,)
+    for s ∈ (Symbol("@no_escape"), Symbol("@alloc"), Symbol("@alloc_ptr"),
+             :default_buffer, :SlabBuffer, :reset_buffer!, :with_buffer)
         println(io, Base.Docs.doc(Base.Docs.Binding(Bumper, s)))
         println(io, "---------------------------------------")
     end

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -1,6 +1,6 @@
 module Bumper
 
-export SlabBuffer, AllocBuffer, @alloc, default_buffer, @no_escape, with_buffer
+export SlabBuffer, AllocBuffer, @alloc, @alloc_ptr, default_buffer, @no_escape, with_buffer
 using StrideArraysCore
 
 
@@ -34,17 +34,33 @@ macro no_escape end
 """
     @alloc(T, n::Int...) -> PtrArray{T, length(n)}
 
-This can only be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions
+This can be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions
 are determined by `n`. The memory used to allocate this array will come from the buffer
 associated with the enclosing `@no_escape` block.
 
 Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do
 not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the
-`@no_escape` block ends. Any array allocated in this way which is found outside of it's parent
-`@no_escape` block has undefined contents.
+`@no_escape` block ends. Any array allocated in this way which is found outside of its parent
+`@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
 """
 macro alloc(args...)
     error("The @alloc macro may only be used inside of a @no_escape block.")
+end
+
+"""
+    @alloc_ptr(n::Integer) -> Ptr{Nothing}
+
+This can be used inside a `@no_escape` block to allocate a pointer whose dimensions
+are determined by `n`. The memory used to allocate this array will come from the buffer
+associated with the enclosing `@no_escape` block.
+
+Do not allow any references to these pointers to escape the enclosing `@no_escape` block, and do
+not pass these pointers to concurrent tasks unless that task is guaranteed to terminate before the
+`@no_escape` block ends. Any pointer allocated in this way which is found outside of its parent
+`@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
+"""
+macro alloc_ptr(args...)
+    error("The @alloc_ptr macro may only be used inside of a @no_escape block.")
 end
 
 """

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -40,6 +40,10 @@ function _no_escape_macro(b_ex, _ex, __module__)
                     Expr(:block,
                          :($tsk === $get_task() || $tsk_err()),
                          Expr(:call, alloc!, b, recursive_handler.(ex.args[3:end])...))
+                elseif ex.args[1] == Symbol("@alloc_ptr")
+                    Expr(:block,
+                         :($tsk === $get_task() || $tsk_err()),
+                         Expr(:call, alloc_ptr!, b, recursive_handler.(ex.args[3:end])...))
                 elseif ex.args[1] == Symbol("@no_escape")
                     # If we encounter nested @no_escape blocks, we'll leave them alone
                     ex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,16 @@ end
     @test sb.current == sb.slabs[1]
     @test sb.slab_end == sb.current + 16_384
 
+    
+    @no_escape sb begin
+        current = sb.current
+        p = @alloc_ptr(10)
+        @test p == current 
+        @test sb.current == p + 10
+        p2 = @alloc_ptr(100_000)
+        @test p2 == sb.custom_slabs[end]
+    end
+    
     try
         @no_escape sb begin
             x = @alloc(Int8, 16_383)


### PR DESCRIPTION
This adds an additional, lower level interface via `@alloc_ptr`  that's like `@alloc` except it only takes a single argument, and is a simple wrapper around `alloc_ptr!($buf, n)`. 

Useful for cases where you don't care about arrays.