### PR TITLE
Adjust size heuristics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7'
           - '1.9'
           - '1.10.0-rc1'
           - 'nightly'

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.5.4
+
++ Changed the default size heuristics for `SlabBuffer`, the default slab size is now 1 megabyte, and custom slabs 
+are now created for allocations which are larger than *half* the slab size, rather than larger than the slab size.
++ Changed the default size heuristic for `AllocBuffer`. `AllocBuffer()` now creates a buffer of 1 megabyte capacity.
+
 ## Version 0.5.3
 
 + Added `@alloc_ptr(n)` which is like `@alloc` except it returns an `n` byte pointer directly instead of an array.

--- a/Docstrings.md
+++ b/Docstrings.md
@@ -34,16 +34,16 @@ end
 
 This can be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
 
-Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
+Do not allow any references to this array to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
 
 ---------------------------------------
 ```
 @alloc_ptr(n::Integer) -> Ptr{Nothing}
 ```
 
-This can be used inside a `@no_escape` block to allocate a pointer whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
+This can be used inside a `@no_escape` block to allocate a pointer which can hold `n` bytes. The memory used to allocate this pointer will come from the buffer associated with the enclosing `@no_escape` block.
 
-Do not allow any references to these pointers to escape the enclosing `@no_escape` block, and do not pass these pointers to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any pointer allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
+Do not allow any references to this pointer to escape the enclosing `@no_escape` block, and do not pass these pointers to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any pointer allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
 
 ---------------------------------------
 ```

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ will reset its internal state to the position it had before the block started, p
 arrays which were created in the block.
 
 In addition to `@alloc` for creating arrays, you can use `@alloc_ptr(n)` to get an `n`-byte pointer (of type
-`Ptr{Cvoid}`) directly.
+`Ptr{Nothing}`) directly.
 
 Let's compare the performance of `f` to the equivalent with an intermediate heap allocation:
 

--- a/src/AllocBuffer.jl
+++ b/src/AllocBuffer.jl
@@ -8,7 +8,7 @@ import Bumper:
     reset_buffer!,
     with_buffer
 
-const default_buffer_size = 128_000
+const default_buffer_size = 1_048_576
 
 """
     AllocBuffer{StorageType}
@@ -25,10 +25,24 @@ end
 
 AllocBuffer(max_size::Int) = AllocBuffer(Vector{UInt8}(undef, max_size), UInt(0))
 AllocBuffer(storage) = AllocBuffer(storage, UInt(0))
+
+"""
+    AllocBuffer() -> AllocBuffer{Vector{UInt8}}
+
+Create an `AllocBuffer` which can hold at most $default_buffer_size bytes.
+"""
 AllocBuffer() = AllocBuffer(Vector{UInt8}(undef, UInt(default_buffer_size)))
 
 const default_buffer_key = gensym(:buffer)
 
+
+"""
+    default_buffer(::Type{AllocBuffer}) -> AllocBuffer{Vector{UInt8}}
+
+Return the current task-local default `AllocBuffer`, if one does not exist in the current task,
+it will create one automatically. This currently can only create `AllocBuffer{Vector{UInt8}}`,
+and you cannot adjust the memory size it creates ($default_buffer_size bytes).
+"""
 function default_buffer(::Type{AllocBuffer})
     get!(() -> AllocBuffer(), task_local_storage(), default_buffer_key)::AllocBuffer{Vector{UInt8}}
 end

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -38,7 +38,7 @@ This can be used inside a `@no_escape` block to allocate a `PtrArray` whose dime
 are determined by `n`. The memory used to allocate this array will come from the buffer
 associated with the enclosing `@no_escape` block.
 
-Do not allow any references to these arrays to escape the enclosing `@no_escape` block, and do
+Do not allow any references to this array to escape the enclosing `@no_escape` block, and do
 not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the
 `@no_escape` block ends. Any array allocated in this way which is found outside of its parent
 `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
@@ -50,11 +50,11 @@ end
 """
     @alloc_ptr(n::Integer) -> Ptr{Nothing}
 
-This can be used inside a `@no_escape` block to allocate a pointer whose dimensions
-are determined by `n`. The memory used to allocate this array will come from the buffer
-associated with the enclosing `@no_escape` block.
+This can be used inside a `@no_escape` block to allocate a pointer which can hold `n` bytes.
+The memory used to allocate this pointer will come from the buffer associated with the
+enclosing `@no_escape` block.
 
-Do not allow any references to these pointers to escape the enclosing `@no_escape` block, and do
+Do not allow any references to this pointer to escape the enclosing `@no_escape` block, and do
 not pass these pointers to concurrent tasks unless that task is guaranteed to terminate before the
 `@no_escape` block ends. Any pointer allocated in this way which is found outside of its parent
 `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -63,13 +63,6 @@ macro alloc_ptr(args...)
     error("The @alloc_ptr macro may only be used inside of a @no_escape block.")
 end
 
-"""
-    default_buffer() -> SlabBuffer{16_384}
-
-Return the current task-local default `SlabBuffer`, if one does not exist in the current task, it will
-create one automatically. This currently only works with `SlabBuffer{16_384}`, and you cannot adjust
-the slab size it creates.
-"""
 function default_buffer end
 
 """
@@ -92,7 +85,8 @@ function alloc_ptr! end
 """
     with_buffer(f, buf)
 
-Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal `default_buffer`. This currently only works with `SlabBuffer{16_384}`, and `AllocBuffer{Vector{UInt8}}`.
+Execute the function `f()` in a context where `default_buffer()` will return `buf` instead of the normal
+`default_buffer`. This currently only works with `SlabBuffer{1_048_576}`, and `AllocBuffer{Vector{UInt8}}`.
 
 Example:
 

--- a/src/SlabBuffer.jl
+++ b/src/SlabBuffer.jl
@@ -126,7 +126,7 @@ function alloc_ptr!(buf::SlabBuffer{SlabSize}, sz::Int)::Ptr{Cvoid} where {SlabS
 end
 
 @noinline function add_new_slab!(buf::SlabBuffer{SlabSize}, sz::Int)::Ptr{Cvoid} where {SlabSize}
-    if sz > (SlabSize ÷ 2)
+    if sz >= (SlabSize ÷ 2)
         custom = malloc(sz)
         push!(buf.custom_slabs, custom)
         custom

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,17 +37,18 @@ end
     @no_escape sb begin
         p = sb.current
         e = sb.slab_end
-        x = @alloc(Int8, 16_383)
+        x = @alloc(Int8, 16_384 ÷ 2 - 1)
+        x = @alloc(Int8, 16_384 ÷ 2 - 1)
         for i ∈ 1:5
             @no_escape sb begin
-                @test sb.current == p + 16_383
+                @test sb.current == p + 16_382
                 @test p <= sb.current <= e
                 y = @alloc(Int, 10)
                 @test !(p <= sb.current <= e)
             end
         end
         z = @alloc(Int, 100_000)
-        @test sb.current == p + 16_383
+        @test sb.current == p + 16_382
         @test sb.slab_end == e
         @test !(p <= pointer(z) <= e)
         @test pointer(z) == sb.custom_slabs[end]


### PR DESCRIPTION
+ Changed the default size heuristics for `SlabBuffer`, the default slab size is now 1 megabyte, and custom slabs 
are now created for allocations which are larger than *half* the slab size, rather than larger than the slab size.
+ Changed the default size heuristic for `AllocBuffer`. `AllocBuffer()` now creates a buffer of 1 megabyte capacity.

I think 1mb is a bit more reasonable. This is also the size where Julia itself starts turning stack allocations into heap allocations:
```julia
julia> code_llvm(Tuple{}, debuginfo=:none) do
           r = Ref{NTuple{1_048_575, UInt8}}()
           Base.donotdelete(r)
       end
define void @"julia_#16_1305"() #0 {
top:
  %0 = alloca [1048575 x i8], align 16
  call void (...) @jl_f_donotdelete([1048575 x i8]* nonnull %0)
  ret void
}
```
versus
```julia
julia> code_llvm(Tuple{}, debuginfo=:none) do
           r = Ref{NTuple{1_048_576, UInt8}}()
           Base.donotdelete(r)
       end
define void @"julia_#14_1303"() #0 {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #9
  %tls_ppgcstack = getelementptr i8, i8* %thread_ptr, i64 -8
  %0 = bitcast i8* %tls_ppgcstack to {}****
  %tls_pgcstack = load {}***, {}**** %0, align 8
  %ptls_field3 = getelementptr inbounds {}**, {}*** %tls_pgcstack, i64 2
  %1 = bitcast {}*** %ptls_field3 to i8**
  %ptls_load45 = load i8*, i8** %1, align 8
  %newstruct = call noalias nonnull dereferenceable(1048584) {}* @ijl_gc_big_alloc(i8* %ptls_load45, i64 1048584) #6
  %2 = bitcast {}* %newstruct to i64*
  %3 = getelementptr inbounds i64, i64* %2, i64 -1
  store atomic i64 139861397231184, i64* %3 unordered, align 8
  call void (...) @jl_f_donotdelete({}* nonnull %newstruct)
  ret void
}
```