### PR TITLE
Drop StrideArrays.jl, move to UnsafeArrays.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,8 +11,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.9'
-          - '1.10.0-rc1'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Docstrings.md
+++ b/Docstrings.md
@@ -18,7 +18,7 @@ Example:
 function f(x::Vector{Int})
     # Set up a scope where memory may be allocated, and does not escape:
     @no_escape begin
-        # Allocate a `PtrArray` from StrideArraysCore.jl using memory from the default buffer.
+        # Allocate a `UnsafeArray` from UnsafeArrays.jl using memory from the default buffer.
         y = @alloc(Int, length(x))
         # Now do some stuff with that vector:
         y .= x .+ 1
@@ -29,10 +29,10 @@ end
 
 ---------------------------------------
 ```
-@alloc(T, n::Int...) -> PtrArray{T, length(n)}
+@alloc(T, n::Int...) -> UnsafeArray{T, length(n)}
 ```
 
-This can be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
+This can be used inside a `@no_escape` block to allocate a `UnsafeArray` whose dimensions are determined by `n`. The memory used to allocate this array will come from the buffer associated with the enclosing `@no_escape` block.
 
 Do not allow any references to this array to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
 
@@ -146,7 +146,7 @@ Take a pointer which can store at least `n` bytes from the allocator `b`.
 
 ---------------------------------------
 ```
-Bumper.alloc!(b, ::Type{T}, n::Int...) -> PtrArray{T, length(n)}
+Bumper.alloc!(b, ::Type{T}, n::Int...) -> UnsafeArray{T, length(n)}
 ```
 
 Function-based alternative to `@alloc` which allocates onto a specified allocator `b`. You must obey all the rules from `@alloc`, but you can use this outside of the lexical scope of `@no_escape` for specific (but dangerous!) circumstances where you cannot avoid a scope barrier between the two.

--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,9 @@ authors = ["MasonProtter <mason.protter@icloud.com>"]
 version = "0.6.0"
 
 [deps]
-StrideArraysCore = "7792a7ef-975c-4747-a70f-980b88e8d1da"
+UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [compat]
-StrideArraysCore = "0.3, 0.4, 0.5"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ using BenchmarkTools
 ```
 
 ```
-BenchmarkTools.Trial: 10000 samples with 997 evaluations.
- Range (min … max):  20.098 ns … 44.669 ns  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     20.802 ns              ┊ GC (median):    0.00%
- Time  (mean ± σ):   20.866 ns ±  0.488 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+BenchmarkTools.Trial: 10000 samples with 995 evaluations.
+ Range (min … max):  28.465 ns … 49.843 ns  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     28.718 ns              ┊ GC (median):    0.00%
+ Time  (mean ± σ):   28.840 ns ±  0.833 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-                 ▄█▃▄▁▄▂ ▁                                     
-  ▂▂▂▂▂▂▂▂▂▂▂▃▃▅▅█████████▆▅▅▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▂▁▁▂▁▁▂▂▂▂▂▂▂▂▂▂▂ ▃
-  20.1 ns         Histogram: frequency by time        22.2 ns <
+  ▃▄▂▇█▅▆▇▅▂▂▁▁▂▁                                             ▂
+  ██████████████████▆▇▅▄▅▅▅▆▃▄▄▁▃▄▄▃▄▃▁▁▁▁▁▃▁▁▁▄▅▅▅▅▄▄▃▄▁▃▃▃▄ █
+  28.5 ns      Histogram: log(frequency) by time      31.5 ns <
 
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
@@ -84,19 +84,20 @@ end
 @benchmark g(x) setup=(x = rand(1:10, 30))
 ```
 ```
-BenchmarkTools.Trial: 10000 samples with 994 evaluations.
- Range (min … max):  33.534 ns … 228.017 ns  ┊ GC (min … max): 0.00% … 78.07%
- Time  (median):     36.599 ns               ┊ GC (median):    0.00%
- Time  (mean ± σ):   37.793 ns ±  13.263 ns  ┊ GC (mean ± σ):  2.60% ±  6.18%
+BenchmarkTools.Trial: 10000 samples with 993 evaluations.
+ Range (min … max):  32.408 ns …  64.986 μs  ┊ GC (min … max):  0.00% … 99.87%
+ Time  (median):     37.443 ns               ┊ GC (median):     0.00%
+ Time  (mean ± σ):   55.929 ns ± 651.009 ns  ┊ GC (mean ± σ):  14.68% ±  5.87%
 
-                     ▂▃▅▅▇█▆▅▃                                  
-  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▄▆███████████▆▅▃▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
-  33.5 ns         Histogram: frequency by time         41.2 ns <
+  ▆█▅▃▁▁▁▁                       ▁▁ ▁                       ▂▁ ▁
+  ████████▇██▅▄▃▄▁▁▃▁▁▁▁▁▁▁▁▃▃▁▁██████▇▇▅▁▄▃▃▃▁▁▃▁▁▁▄▃▄▅▄▄▅▇██ █
+  32.4 ns       Histogram: log(frequency) by time       227 ns <
 
  Memory estimate: 304 bytes, allocs estimate: 1.
 ```
 
-Nice speedup!
+So, using Bumper.jl in this benchmark gives a slight speedup relative to regular julia `Vector`s,
+and a major increase in performance *consistency* due to the lack of heap allocations.
 
 However, we can actually go a little faster better if we're okay with manually passing around a buffer.
 The way I invoked `@no_escape` and `@alloc` implicitly used the task's default buffer, and fetching that
@@ -120,14 +121,14 @@ end
 end
 ```
 ```
-BenchmarkTools.Trial: 10000 samples with 998 evaluations.
- Range (min … max):  14.235 ns … 29.103 ns  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     14.737 ns              ┊ GC (median):    0.00%
- Time  (mean ± σ):   14.791 ns ±  0.594 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+BenchmarkTools.Trial: 10000 samples with 997 evaluations.
+ Range (min … max):  19.425 ns … 40.367 ns  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     19.494 ns              ┊ GC (median):    0.00%
+ Time  (mean ± σ):   19.620 ns ±  0.983 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
 
-     ▁▁▄   ▅▇█                                                 
-  ▁▂▃███▇▇████▅▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
-  14.2 ns         Histogram: frequency by time        17.4 ns <
+  █▅                                                          ▁
+  ██▅█▇▄▃▄▄▃▃▃▄▅▄▅▄▅▄▇▇▅▄▄▅▆▅▅▅▄▄▄▁▄▃▃▃▁▁▄▃▃▄▁▁▁▁▃▃▃▁▄▄▃▁▄▃▁▃ █
+  19.4 ns      Histogram: log(frequency) by time      25.3 ns <
 
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```

--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ The simplest way to use Bumper is to rely on its default buffer implicitly like 
 
 ``` julia
 using Bumper
-using StrideArrays # Not necessary, but can make operations like broadcasting with Bumper.jl faster.
 
 function f(x)
     # Set up a scope where memory may be allocated, and does not escape:
     @no_escape begin
-        # Allocate a `PtrArray` (see StrideArraysCore.jl) using memory from the default buffer.
+        # Allocate a `UnsafeVector{eltype(x)}` (see UnsafeArrays.jl) using memory from the default buffer.
         y = @alloc(eltype(x), length(x))
         # Now do some stuff with that vector:
         y .= x .+ 1
@@ -157,7 +156,6 @@ an error if you overfill them.
   *block to escape the block.* Doing so will cause incorrect results.
 - If you accidentally overfill a buffer, via e.g. a memory leak and need to reset the buffer, use
   `Bumper.reset_buffer!` to do this.
-- In order to be lightweight, Bumper.jl only depends on [StrideArraysCore.jl](https://github.com/JuliaSIMD/StrideArraysCore.jl), not the full [StrideArrays.jl](https://github.com/JuliaSIMD/StrideArrays.jl), so if you need some of the more advanced functionality from StrideArrays.jl itself, you'll need to do `using StrideArrays` separately.
 - You are not allowed to use `return` or `@goto` inside a `@no_escape` block, since this could compromise the cleanup it performs after the block finishes.
 
 

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -1,7 +1,7 @@
 module Bumper
 
 export SlabBuffer, AllocBuffer, @alloc, @alloc_ptr, default_buffer, @no_escape, with_buffer
-using StrideArraysCore
+using UnsafeArrays: UnsafeArrays, UnsafeArray
 
 
 """
@@ -21,7 +21,7 @@ Example:
     function f(x::Vector{Int})
         # Set up a scope where memory may be allocated, and does not escape:
         @no_escape begin
-            # Allocate a `PtrArray` from StrideArraysCore.jl using memory from the default buffer.
+            # Allocate a `UnsafeArray` from UnsafeArrays.jl using memory from the default buffer.
             y = @alloc(Int, length(x))
             # Now do some stuff with that vector:
             y .= x .+ 1
@@ -32,9 +32,9 @@ Example:
 macro no_escape end
 
 """
-    @alloc(T, n::Int...) -> PtrArray{T, length(n)}
+    @alloc(T, n::Int...) -> UnsafeArray{T, length(n)}
 
-This can be used inside a `@no_escape` block to allocate a `PtrArray` whose dimensions
+This can be used inside a `@no_escape` block to allocate a `UnsafeArray` whose dimensions
 are determined by `n`. The memory used to allocate this array will come from the buffer
 associated with the enclosing `@no_escape` block.
 
@@ -66,7 +66,7 @@ end
 function default_buffer end
 
 """
-    Bumper.alloc!(b, ::Type{T}, n::Int...) -> PtrArray{T, length(n)}
+    Bumper.alloc!(b, ::Type{T}, n::Int...) -> UnsafeArray{T, length(n)}
 
 Function-based alternative to `@alloc` which allocates onto a specified allocator `b`.
 You must obey all the rules from `@alloc`, but you can use this outside of the lexical

--- a/src/SlabBuffer.jl
+++ b/src/SlabBuffer.jl
@@ -126,7 +126,7 @@ function alloc_ptr!(buf::SlabBuffer{SlabSize}, sz::Int)::Ptr{Cvoid} where {SlabS
 end
 
 @noinline function add_new_slab!(buf::SlabBuffer{SlabSize}, sz::Int)::Ptr{Cvoid} where {SlabSize}
-    if sz >= (SlabSize ÷ 2)
+    if sz >= SlabSize
         custom = malloc(sz)
         push!(buf.custom_slabs, custom)
         custom

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -1,6 +1,6 @@
 module Internals
 
-using StrideArraysCore
+using UnsafeArrays: UnsafeArrays, UnsafeArray
 import Bumper:
     @no_escape,
     alloc!,
@@ -73,7 +73,7 @@ function _no_escape_macro(b_ex, _ex, __module__)
         local cp = checkpoint_save($e_b)
         local res = $(esc(ex))
         checkpoint_restore!(cp)
-        if res isa PtrArray && !(allow_ptr_array_to_escape())
+        if res isa UnsafeArray && !(allow_ptr_array_to_escape())
            esc_err()
         end
         res
@@ -84,11 +84,11 @@ end
     error("Tried to use @alloc from a different task than its parent @no_escape block, that is not allowed for thread safety reasons. If you really need to do this, see Bumper.alloc instead of @alloc.")
 
 @noinline esc_err() =
-    error("Tried to return a PtrArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
+    error("Tried to return a UnsafeArray from a `no_escape` block. If you really want to do this, evaluate Bumper.allow_ptrarray_to_escape() = true")
 
 function alloc!(buf, ::Type{T}, s::Vararg{Integer, N}) where {T, N}
     ptr::Ptr{T} = alloc_ptr!(buf, prod(s) * sizeof(T))
-    PtrArray(ptr, s)
+    UnsafeArray(ptr, s)
 end
 
 


### PR DESCRIPTION
closes #34 sorry @milescranmer it took me so long to get around to this. None of the options I looked at were as fast as StrideArrays.jl, but eventually I decided it didn't really matter because they were at least faster than `Array`.

I had hoped to find the time to figure out how to make up the remainder of the performance difference, but I never got around to it, so now I'm thinking lets just go forward with UnsafeArrays.jl

Let me know what you think. 