### PR TITLE
add `show` method for `AllocBuffer`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.7.1
+
+- Adds `show` method for `AllocBuffer`
+
 ## Version 0.7.0
 
 - The type of array created by `@alloc` and `alloc!` has been changed from a `StrideArraysCore.PtrArray` to `UnsafeArrays.UnsafeArray`. This shouldn't matter for most purposes, but can break code that relies on a specific return type.

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,10 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.3"
+manifest_format = "2.0"
+project_hash = "9c7dafb9c0018fdb4511242a2b1ceb9d85d8681f"
+
+[[deps.UnsafeArrays]]
+git-tree-sha1 = "d32529bcc1dcef5ff8cf5b6df9c5862c224fa264"
+uuid = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
+version = "1.0.7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"

--- a/src/AllocBuffer.jl
+++ b/src/AllocBuffer.jl
@@ -77,4 +77,9 @@ end
 Use Bumper.reset_buffer!(b::AllocBuffer) to reclaim its memory.")
 end
 
+function Base.show(io::IO, b::AllocBuffer)
+    cap = length(b.buf)
+    print(io, "$(typeof(b))(…used=",min(Int(b.offset), cap), ", capacity=",cap, "…)")
+end
+
 end # module AllocBufferImpl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,8 @@ function f(x, buf=default_buffer())
 end
 
 function g(x, buf)
-    @no_escape buf begin 
-        y = Bumper.alloc!(buf, eltype(x), length(x)) 
+    @no_escape buf begin
+        y = Bumper.alloc!(buf, eltype(x), length(x))
         y .= x .+ 1
         sum(y)
     end
@@ -28,7 +28,7 @@ end
     @test b.offset == 0
     @test g(v, b)  == 9
     @test b.offset == 0
-    
+
     @test @allocated(f(v)) == 0
     @test @allocated(f(v, b)) == 0
     @test @allocated(g(v, b)) == 0
@@ -57,16 +57,16 @@ end
     @test sb.current == sb.slabs[1]
     @test sb.slab_end == sb.current + 16_384
 
-    
+
     @no_escape sb begin
         current = sb.current
         p = @alloc_ptr(10)
-        @test p == current 
+        @test p == current
         @test sb.current == p + 10
         p2 = @alloc_ptr(100_000)
         @test p2 == sb.custom_slabs[end]
     end
-    
+
     try
         @no_escape sb begin
             x = @alloc(Int8, 16_383)
@@ -78,20 +78,20 @@ end
         @test length(sb.custom_slabs) == 1
         @test length(sb.slabs) == 2
         @test sb.current  == sb.slabs[2] + 10
-        
+
         Bumper.reset_buffer!(sb)
 
         @test isempty(sb.custom_slabs)
         @test length(sb.slabs) == 1
         @test sb.current  == sb.slabs[1]
     end
-    
+
     @no_escape b begin
         y = @alloc(Int, length(v))
         off1 = b.offset
         @no_escape b begin
             z = @alloc(Int, length(v))
-            
+
             @test pointer(z) != pointer(y)
             @test Int(pointer(z)) == Int(pointer(y)) + 8*length(v)
             @test b.offset == off1 + 8*length(v)
@@ -101,7 +101,7 @@ end
             z = @alloc(Int, length(v))
             @test pointer(z) == pointer(b2.buf)
         end
-        
+
         @test b.offset == off1
     end
 
@@ -132,11 +132,11 @@ end
     # It is very tricky to properly deal with code which uses @goto or return inside
     # a @no_escape code block, because could bypass the mechanism for resetting the
     # buffer's offset after the block completes.
-    
+
     # I played with some mechanisms for cleaning it up, but they were sometimes incorrect
     # if one nested multuple @no_escape blocks, so I decided that they should simply be
     # disabled, and throw an error at macroexpansion time.
-    
+
     @test_throws Exception Bumper.Internals._no_escape_macro(
         :(default_buffer()),
         :(return sum(@alloc(Int, 10) .= 1)),
@@ -178,12 +178,32 @@ end
             default_buffer()
         end
     end
-    
+
     @test default_buffer() === default_buffer()
     @test default_buffer() !== fetch(@async default_buffer())
     @test default_buffer() !== fetch(Threads.@spawn default_buffer())
-    
+
     @test default_buffer() !== with_buffer(default_buffer, SlabBuffer())
     @test default_buffer(AllocBuffer) === default_buffer(AllocBuffer)
     @test default_buffer(AllocBuffer) !== with_buffer(() -> default_buffer(AllocBuffer), AllocBuffer())
+end
+
+@testset "show" begin
+    b = AllocBuffer(100)
+    @test sprint(show, b) == "AllocBuffer{Vector{UInt8}}(…used=0, capacity=100…)"
+    Bumper.alloc!(b, UInt8, 50)
+    @test sprint(show, b) == "AllocBuffer{Vector{UInt8}}(…used=50, capacity=100…)"
+    Bumper.alloc!(b, UInt8, 50)
+    @test sprint(show, b) == "AllocBuffer{Vector{UInt8}}(…used=100, capacity=100…)"
+
+    @static if VERSION > v"1.8-"
+        try
+            Bumper.alloc!(b, UInt8, 1)
+        catch e
+            @test sprint(show, b) == "AllocBuffer{Vector{UInt8}}(…used=100, capacity=100…)"
+        else
+            @test false
+        end
+    end
+
 end


### PR DESCRIPTION
main:
```julia
julia> b = AllocBuffer(100)
AllocBuffer{Vector{UInt8}}(UInt8[0x4c, 0x69, 0x62, 0x72, 0x61, 0x72, 0x79, 0x2f, 0x46, 0x72  …  0x73, 0x2f, 0x41, 0x2f, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61], 0x0000000000000000)
```

PR:

```julia
julia> b = AllocBuffer(100)
AllocBuffer{Vector{UInt8}}(…used=0, capacity=100…)
```

Not a huge deal by itself but the default show for AllocBuffer is part of the problem here:

``julia
julia> yolomod
AllocWrappedModel
Model:
YOLO v3. Trained with DarkNet 0.2.0
WxH: 608x608   channels: 3   batchsize: 1
gridsize: 19x19   classes: 80   thresholds: Detect 0.6. Overlap 0.4
Allocator:
AllocArrays.BumperAllocator{AllocArrays.UncheckedBumperAllocator{AllocArrays.AutoscalingAllocBuffer}}(AllocArrays.UncheckedBumperAllocator{AllocArrays.AutoscalingAllocBuffer}(AllocArrays.AutoscalingAllocBuffer(Bumper.AllocBufferImpl.AllocBuffer{Vector{UInt8}}(UInt8[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  …  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], 0x0000000000000000), Bumper.AllocBufferImpl.AllocBuffer{Vector{UInt8}}[], 67108864, [134217728], 5)), AllocArrays.MemValid[], ReentrantLock(nothing, 0x00000000, 0x00, Base.GenericCondition{Base.Threads.SpinLock}(Base.IntrusiveLinkedList{Task}(nothing, nothing), Base.Threads.SpinLock(0)), (256, 1, 0)))

```

