### PR TITLE
Add `ResizeBuffer`: automatically growing buffer

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,11 +19,11 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.7.2
+
++ Added `ResizeBuffer`: an adaptive bump allocator for workflows where the required memory is not known in advance. It uses a fixed internal buffer and falls back to overflow heap allocations when full. On `reset_buffer!`, it resizes its internal buffer to the observed peak usage to reduce future overflow.
+
 ## Version 0.7.0
 
 - The type of array created by `@alloc` and `alloc!` has been changed from a `StrideArraysCore.PtrArray` to `UnsafeArrays.UnsafeArray`. This shouldn't matter for most purposes, but can break code that relies on a specific return type.

--- a/Docstrings.md
+++ b/Docstrings.md
@@ -2,7 +2,7 @@
 
 ## User API
 
-```
+```julia
 @no_escape([buf=default_buffer()], expr)
 ```
 
@@ -14,7 +14,7 @@ Using `return`, `@goto`, and `@label` are not allowed inside of `@no_escape` blo
 
 Example:
 
-```
+```julia
 function f(x::Vector{Int})
     # Set up a scope where memory may be allocated, and does not escape:
     @no_escape begin
@@ -28,7 +28,7 @@ end
 ```
 
 ---------------------------------------
-```
+```julia
 @alloc(T, n::Int...) -> UnsafeArray{T, length(n)}
 ```
 
@@ -37,7 +37,7 @@ This can be used inside a `@no_escape` block to allocate a `UnsafeArray` whose d
 Do not allow any references to this array to escape the enclosing `@no_escape` block, and do not pass these arrays to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any array allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
 
 ---------------------------------------
-```
+```julia
 @alloc_ptr(n::Integer) -> Ptr{Nothing}
 ```
 
@@ -46,26 +46,32 @@ This can be used inside a `@no_escape` block to allocate a pointer which can hol
 Do not allow any references to this pointer to escape the enclosing `@no_escape` block, and do not pass these pointers to concurrent tasks unless that task is guaranteed to terminate before the `@no_escape` block ends. Any pointer allocated in this way which is found outside of its parent `@no_escape` block has undefined contents, and writing to this pointer will have undefined behaviour.
 
 ---------------------------------------
-```
+```julia
 default_buffer(::Type{SlabBuffer}) -> SlabBuffer{1048576}
 ```
 
 Return the current task-local default `SlabBuffer`, if one does not exist in the current task, it will create one automatically. This currently can only create `SlabBuffer{1048576}`, and you cannot adjust the slab size it creates.
 
-```
+```julia
 default_buffer() -> SlabBuffer{1048576}
 ```
 
 Return the current task-local default `SlabBuffer`, if one does not exist in the current task, it will create one automatically. This currently only works with `SlabBuffer{1048576}`, and you cannot adjust the slab size it creates.
 
-```
+```julia
 default_buffer(::Type{AllocBuffer}) -> AllocBuffer{Vector{UInt8}}
 ```
 
 Return the current task-local default `AllocBuffer`, if one does not exist in the current task, it will create one automatically. This currently can only create `AllocBuffer{Vector{UInt8}}`, and you cannot adjust the memory size it creates (1048576 bytes).
 
----------------------------------------
+```julia
+default_buffer(::Type{ResizeBuffer}) -> ResizeBuffer
 ```
+
+Return the current task-local default `ResizeBuffer`, creating one automatically if it does not yet exist in the current task.
+
+---------------------------------------
+```julia
 mutable struct SlabBuffer{SlabSize}
 ```
 
@@ -75,7 +81,7 @@ The default slab size is 1048576 bytes.
 
 `SlabBuffer`s are nearly as fast as stack allocation (typically up to within a couple of nanoseconds) for typical use. One potential performance pitfall is if that `SlabBuffer`'s current position is at the end of a slab, then the next allocation will be slow because it requires a new slab to be created. This means that if you do something like
 
-```
+```julia
 buf = SlabBuffer{N}()
 @no_escape buf begin
     @alloc(Int8, N÷2 - 1) # Take up just under half the first slab
@@ -94,27 +100,43 @@ then the inner loop will run slower than normal because at each iteration, a new
 
 Do not manipulate the fields of a SlabBuffer that is in use.
 
-```
+```julia
 SlabBuffer{SlabSize}(;finalize::Bool = true)
 ```
 
 Create a slab allocator whose slabs are of size `SlabSize`. If you set the `finalize` keyword argument to `false`, then you will need to explicitly call `Bumper.free()` when you are done with a `SlabBuffer`. This is not recommended.
 
-```
+```julia
 SlabBuffer(;finalize::Bool = true)
 ```
 
 Create a slab allocator whose slabs are of size 1048576. If you set the `finalize` keyword argument to `false`, then you will need to explicitly call `Bumper.free()` when you are done with a `SlabBuffer`. This is not recommended.
 
 ---------------------------------------
+```julia
+ResizeBuffer
+ResizeBuffer(max_size = 1048576; finalize::Bool = true)
 ```
+
+*New in v0.7.2.*
+
+An adaptive bump allocator oriented towards workflows that repeatedly perform a similar operation where the amount of memory needed is not known a priori. Allocations are served from an internal fixed buffer; when that buffer is exhausted, overflow allocations are made on the heap so no allocation ever fails. Upon a full `reset_buffer!`, overflow memory is freed and the internal buffer is resized to the peak observed usage, so that future iterations of the same operation avoid overflow entirely.
+
+In contrast, `SlabBuffer` frees extra slabs when their allocations are released and does not retain memory between operations — it "forgets" peak usage and shrinks back to its baseline size. `ResizeBuffer` is the better choice when you expect to repeat the same memory-intensive operation many times and want the allocator to warm up to the right size rather than paying the cost of fresh slab allocation on each call.
+
+The initial buffer capacity is given by `max_size`. If you set the `finalize` keyword argument to `false`, then you will need to explicitly call `Bumper.free(buf)` when you are done with the `ResizeBuffer`. This is not recommended.
+
+Do not manually manipulate the fields of a `ResizeBuffer` that is in use.
+
+---------------------------------------
+```julia
 Bumper.reset_buffer!(buf=default_buffer())
 ```
 
 This resets a buffer to its default state, effectively making it like a freshly allocated buffer. This might be necessary to use if you accidentally over-allocate a buffer or screw up its state in some other way.
 
 ---------------------------------------
-```
+```julia
 with_buffer(f, buf)
 ```
 
@@ -122,7 +144,7 @@ Execute the function `f()` in a context where `default_buffer()` will return `bu
 
 Example:
 
-```
+```julia
 julia> let b1 = default_buffer()
            b2 = SlabBuffer()
            with_buffer(b2) do
@@ -138,21 +160,21 @@ true
 ---------------------------------------
 ## Allocator API
 
-```
+```julia
 Bumper.alloc_ptr!(b, n::Int) -> Ptr{Nothing}
 ```
 
 Take a pointer which can store at least `n` bytes from the allocator `b`.
 
 ---------------------------------------
-```
+```julia
 Bumper.alloc!(b, ::Type{T}, n::Int...) -> UnsafeArray{T, length(n)}
 ```
 
 Function-based alternative to `@alloc` which allocates onto a specified allocator `b`. You must obey all the rules from `@alloc`, but you can use this outside of the lexical scope of `@no_escape` for specific (but dangerous!) circumstances where you cannot avoid a scope barrier between the two.
 
 ---------------------------------------
-```
+```julia
 Bumper.checkpoint_save(buf = default_buffer())
 ```
 
@@ -161,7 +183,7 @@ Returns a checkpoint object `cp` which stores the state of a `buf` at a given po
 Users should prefer to use `@no_escape` instead of `checkpoint_save` and `checkpoint_restore`, which is a safer and more structured way of doing the same thing.
 
 ---------------------------------------
-```
+```julia
 Bumper.checkpoint_restore!(cp)
 ```
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Bumper"
 uuid = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 authors = ["MasonProtter <mason.protter@icloud.com>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"

--- a/README.md
+++ b/README.md
@@ -138,8 +138,10 @@ multiple concurrent tasks using that buffer at the same time.
 
 Running `default_buffer()` will give you the current task's default buffer. You can explicitly construct
 your own `N` byte buffer by calling `AllocBuffer(N)`, or you can create a buffer which can dynamically
-grow by calling `SlabBuffer()`. `AllocBuffer`s are *slightly* faster than `SlabBuffer`s, but will throw 
-an error if you overfill them.
+grow by calling `SlabBuffer()`. `AllocBuffer`s are *slightly* faster than `SlabBuffer`s, but will throw
+an error if you overfill them. You can also create a `ResizeBuffer()`, which starts with a fixed buffer
+but adaptively resizes itself upon a full reset to reduce future overflow — making it well-suited for
+repeated operations where the memory footprint is not known in advance.
 
 ## Important notes
 
@@ -248,6 +250,30 @@ will be thrown. By default, `AllocBuffer` stores a `Vector{UInt8}` of `1` megaby
 Allocations using `AllocBuffer`s should be just as fast as stack allocation.
 
 Do not manually manipulate the fields of an AllocBuffer that is in use.
+
+### ResizeBuffer
+
+*New in v0.7.2.*
+
+`ResizeBuffer` is an adaptive bump allocator oriented towards workflows that repeatedly perform a similar
+operation for which it is not easy to determine upfront how much memory is needed. It holds an internal
+fixed-size buffer and serves allocations from it as long as capacity permits. When the buffer is
+exhausted, overflow allocations are made directly on the heap so that no allocation ever fails.
+
+Upon calling `reset_buffer!` on a `ResizeBuffer`, all overflow memory is freed and the internal buffer is
+resized to the peak memory usage observed since the last full reset. This means that if you repeatedly
+perform the same operation, the buffer will converge to the right size and avoid overflow allocations
+entirely after the first iteration or two.
+
+This contrasts with `SlabBuffer`, which frees any extra slabs it acquired during a large allocation as
+soon as those allocations are released. A `SlabBuffer` will shrink back to its baseline size after a
+`@no_escape` block completes, "forgetting" how much memory was needed. A `ResizeBuffer` deliberately
+retains that information, keeping a large buffer available for the next time the same operation runs.
+
+By default, `ResizeBuffer` creates a buffer with 1 megabyte of initial capacity. You can adjust this with
+`ResizeBuffer(n)`. A task-local default `ResizeBuffer` is accessible via `default_buffer(ResizeBuffer)`.
+
+Do not manually manipulate the fields of a ResizeBuffer that is in use.
 
 </details>
 </p>

--- a/docstring_generator.jl
+++ b/docstring_generator.jl
@@ -4,12 +4,12 @@ open("Docstrings.md", "w+") do io
     println(io, "# Docstrings\n")
     println(io, "## User API\n")
     for s ∈ (Symbol("@no_escape"), Symbol("@alloc"), Symbol("@alloc_ptr"),
-             :default_buffer, :SlabBuffer, :reset_buffer!, :with_buffer)
+             :default_buffer, :SlabBuffer, :ResizeBuffer, :reset_buffer!, :with_buffer)
         println(io, Base.Docs.doc(Base.Docs.Binding(Bumper, s)))
         println(io, "---------------------------------------")
     end
     println(io, "## Allocator API\n")
-    for s ∈ (:alloc_ptr!,  :alloc!, :checkpoint_save, :checkpoint_restore!)
+    for s ∈ (:alloc_ptr!, :alloc!, :checkpoint_save, :checkpoint_restore!)
         println(io, Base.Docs.doc(Base.Docs.Binding(Bumper, s)))
         println(io, "---------------------------------------")
     end

--- a/src/Bumper.jl
+++ b/src/Bumper.jl
@@ -1,6 +1,6 @@
 module Bumper
 
-export SlabBuffer, AllocBuffer, @alloc, @alloc_ptr, default_buffer, @no_escape, with_buffer
+export SlabBuffer, AllocBuffer, ResizeBuffer, @alloc, @alloc_ptr, default_buffer, @no_escape, with_buffer
 using UnsafeArrays: UnsafeArrays, UnsafeArray
 
 
@@ -154,6 +154,8 @@ import .SlabBufferImpl: SlabBuffer
 include("AllocBuffer.jl")
 import .AllocBufferImpl: AllocBuffer
 
+include("ResizeBuffer.jl")
+import .ResizeBufferImpl: ResizeBuffer
 
 
 end # Bumper

--- a/src/ResizeBuffer.jl
+++ b/src/ResizeBuffer.jl
@@ -1,0 +1,113 @@
+module ResizeBufferImpl
+
+
+import Bumper:
+    alloc_ptr!,
+    checkpoint_save,
+    checkpoint_restore!,
+    default_buffer,
+    reset_buffer!,
+    with_buffer
+import Bumper.Internals: malloc, free
+
+const default_max_size = 1_048_576
+
+"""
+    ResizeBuffer{StorageType}
+
+This is a simple bump allocator that could be used to store a fixed amount of memory of type
+`StorageType`, so long as `::StorageType` supports `pointer`, and `sizeof`.
+
+Do not manually manipulate the fields of a `ResizeBuffer` that is in use.
+"""
+mutable struct ResizeBuffer
+    buf::Ptr{Cvoid}
+    buf_len::UInt
+
+    offset::UInt
+    max_offset::UInt
+
+    overflow::Vector{Ptr{Cvoid}}
+
+    function ResizeBuffer(max_size::Int = default_max_size; finalize::Bool = true)
+        buf = malloc(max_size)
+        buf_len = max_size
+        overflow = Ptr{Cvoid}[]
+        resizebuf = new(buf, buf_len, UInt(0), UInt(0), overflow)
+        finalize && finalizer(free, resizebuf)
+        return resizebuf
+    end
+end
+
+function free(buf::ResizeBuffer)
+    foreach(free, buf.overflow)
+    free(buf.buf)
+    return nothing
+end
+
+const default_buffer_key = gensym(:buffer)
+
+
+"""
+    default_buffer(::Type{ResizeBuffer}) -> ResizeBuffer
+
+Return the current task-local default `ResizeBuffer`, if one does not exist in the current task,
+it will create one automatically.
+"""
+function default_buffer(::Type{ResizeBuffer})
+    return get!(() -> ResizeBuffer(), task_local_storage(), default_buffer_key)::ResizeBuffer
+end
+
+function alloc_ptr!(b::ResizeBuffer, sz::Int)::Ptr{Cvoid}
+    old_offset = b.offset
+    b.offset += sz
+    b.max_offset = max(b.max_offset, b.offset)
+
+    # grow the buffer - only available if empty
+    if iszero(old_offset) & (b.max_offset > b.buf_len)
+        free(b.buf)
+        b.buf = malloc(b.max_offset)
+        b.buf_len = b.max_offset
+    end
+
+    if b.offset ≤ b.buf_len     # use the buffer if there is enough space
+        ptr = b.buf + old_offset
+    else                        # manually allocate if not
+        ptr = malloc(sz)
+        push!(b.overflow, ptr)
+    end
+
+    return ptr
+end
+
+function reset_buffer!(b::ResizeBuffer)
+    b.offset = UInt(0)
+    b.max_offset = UInt(0) # do we want this?
+
+    foreach(free, b.overflow)
+    resize!(b.overflow, 0)
+
+    return b
+end
+
+struct ResizeCheckpoint
+    buf::ResizeBuffer
+    offset::UInt
+    overflow_length::Int
+end
+
+checkpoint_save(buf::ResizeBuffer) = ResizeCheckpoint(buf, buf.offset, length(buf.overflow))
+function checkpoint_restore!(cp::ResizeCheckpoint)
+    # restore overflow
+    foreach(free, @view cp.buf.overflow[(cp.overflow_length + 1):end])
+    resize!(cp.buf.overflow, cp.overflow_length)
+
+    # restore offset
+    cp.buf.offset = cp.offset
+
+    return nothing
+end
+
+with_buffer(f, b::ResizeBuffer) = task_local_storage(f, default_buffer_key, b)
+
+end # module ResizeBufferImpl

--- a/src/ResizeBuffer.jl
+++ b/src/ResizeBuffer.jl
@@ -14,13 +14,25 @@ const default_max_size = 1_048_576
 
 """
     ResizeBuffer
+    ResizeBuffer(max_size = $default_max_size; finalize::Bool = true)
 
-This is an adaptive bump allocator that is oriented towards workflows that repeatedly perform a similar operation,
-for which it is a priori not easy to determine how much memory is needed.
-It stores both a buffer that will be used for allocations as long as its capacity is not exceeded,
-as well as allowing for overflow whenever the requested memory exceeds the capacity size.
-Upon fully resetting the `ResizeBuffer`, it will adaptively resize to avoid having to overflow if the same operation
-is carried out again.
+*New in v0.7.2.*
+
+An adaptive bump allocator oriented towards workflows that repeatedly perform a similar operation where
+the amount of memory needed is not known a priori. Allocations are served from an internal fixed buffer;
+when that buffer is exhausted, overflow allocations are made on the heap so no allocation ever fails.
+Upon a full `reset_buffer!`, overflow memory is freed and the internal buffer is resized to the
+peak observed usage, so that future iterations of the same operation avoid overflow entirely.
+
+In contrast, `SlabBuffer` frees extra slabs when their allocations are released and does not retain
+memory between operations — it "forgets" peak usage and shrinks back to its baseline size.
+`ResizeBuffer` is the better choice when you expect to repeat the same memory-intensive operation many
+times and want the allocator to warm up to the right size rather than paying the cost of fresh slab
+allocation on each call.
+
+The initial buffer capacity is given by `max_size`. If you set the `finalize` keyword argument to
+`false`, then you will need to explicitly call `Bumper.free(buf)` when you are done with the
+`ResizeBuffer`. This is not recommended.
 
 Do not manually manipulate the fields of a `ResizeBuffer` that is in use.
 """
@@ -43,14 +55,6 @@ mutable struct ResizeBuffer
     end
 end
 
-@doc """
-    ResizeBuffer(max_size = $default_max_size; finalize::Bool = true)
-
-Create an adaptive bump allocator where the initial size is given by `max_size`.
-If you set the `finalize` keyword argument to `false`, then you will need to explicitly
-call `Bumper.free(buf)` when you are done with the `ResizeBuffer`. This is not recommended.
-""" ResizeBuffer
-
 function free(buf::ResizeBuffer)
     foreach(free, buf.overflow)
     free(buf.buf)
@@ -63,8 +67,8 @@ const default_buffer_key = gensym(:buffer)
 """
     default_buffer(::Type{ResizeBuffer}) -> ResizeBuffer
 
-Return the current task-local default `ResizeBuffer`, if one does not exist in the current task,
-it will create one automatically.
+Return the current task-local default `ResizeBuffer`, creating one automatically if it does not yet
+exist in the current task.
 """
 function default_buffer(::Type{ResizeBuffer})
     return get!(() -> ResizeBuffer(), task_local_storage(), default_buffer_key)::ResizeBuffer


### PR DESCRIPTION
This is the port of some work I did [for TensorOperations.jl](https://github.com/QuantumKitHub/TensorOperations.jl/pull/251).

The idea is that in a workflow that repeatedly does the same task that might allocate large objects, but where it is a priori difficult to foresee how much memory is needed, this approach attempts to strike a balance between user-friendly, performance, and number of allocations.
The approach is simple, we keep a buffer alive like `AllocBuffer`, but instead of erroring whenever we oversubscribe the buffer, we manually allocate extra objects (more like the `SlabBuffer`).
Additionally, we keep a counter that simply keeps track of the maximal size that would have been reached if the buffer were sufficiently large, and after resetting the buffer, the next allocation will trigger a resize to account for that.

Note that this still needs some work, but could already do with a review.
warning that the tests have been AI generated and I still have to find the time to review that more closely myself!

Additionally I still have to have a look at the docs and make sure these are updated as well.